### PR TITLE
Creates repository factory

### DIFF
--- a/src/Happyr/Doctrine/ORM/BaseEntitySpecificationRepository.php
+++ b/src/Happyr/Doctrine/ORM/BaseEntitySpecificationRepository.php
@@ -1,0 +1,10 @@
+<?php
+namespace Happyr\Doctrine\ORM;
+
+
+class BaseEntitySpecificationRepository extends \Happyr\Doctrine\Specification\EntitySpecificationRepository
+{
+    // Implements nothing extra.
+    // Merely provides a concrete instance of \Happyr\Doctrine\Specification\EntitySpecificationRepository
+    // to use with \Happyr\Doctrime\ORM\EntitySpecificationRepositoryFactory
+} 

--- a/src/Happyr/Doctrine/ORM/EntitySpecificationRepositoryFactory.php
+++ b/src/Happyr/Doctrine/ORM/EntitySpecificationRepositoryFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Happyr\Doctrine\ORM;
+
+use Doctrine\ORM\EntityManagerInterface;
+
+class EntitySpecificationRepositoryFactory implements \Doctrine\ORM\Repository\RepositoryFactory
+{
+    /**
+     * Gets the repository for an entity class.
+     *
+     * @param \Doctrine\ORM\EntityManagerInterface $entityManager The EntityManager instance.
+     * @param string $entityName The name of the entity.
+     *
+     * @return \Doctrine\Common\Persistence\ObjectRepository
+     */
+    public function getRepository(EntityManagerInterface $entityManager, $entityName)
+    {
+        return new BaseEntitySpecificationRepository($entityManager, $entityManager->getClassMetadata($entityName));
+    }
+}


### PR DESCRIPTION
Having read through #20, I'm not sure if this is within scope for the library, but I thought I'd make the PR anyway.

When making use of the library, I found myself wanting to use the EntitySpecificationRepository for the default implementation of repositories using `$em->getRepository("Entity")` when `Entity` doesn't have a specific repository. I suspect that the implementation of the factory and base class will be largely the same in almost every consumers codebase, so I figure providing somethign standard out of the box can't hurt.

Example

```
$cfg = new \Doctrine\ORM\Configuration();
$cfg->setRepositoryFactory(new \Happyr\Doctrine\ORM\EntitySpecificationRepositoryFactory());

// Later on

use 
/** @var \Happyr\Doctrine\Specification\EntitySpecificationRepository $repo **/
$repo = $em->getRepository("Entity");
```
