### PR TITLE
Run Coverage only on Travis

### DIFF
--- a/.phpspec-travis.yml
+++ b/.phpspec-travis.yml
@@ -1,4 +1,3 @@
-
 extensions:
   - PhpSpec\Extension\CodeCoverageExtension
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - mkdir -p build/logs
 
 script:
-  - ./vendor/bin/phpspec run
+  - ./vendor/bin/phpspec --config=.phpspec-travis.yml run
 
 after_success:
   - php vendor/bin/coveralls -v


### PR DESCRIPTION
Hello,

I've tweaked config a bit and now by default PHPSpec runs without coverage (it's not really needed during development and was slowing tests :) ).
