### PR TITLE
Base type documentation

### DIFF
--- a/docs/0-0-symfony.md
+++ b/docs/0-0-symfony.md
@@ -7,5 +7,5 @@ Replacing Doctrine's default repository type with `\Happyr\Doctrine\Specificatio
 // app/config/config.yml
 doctrine:
   orm:
-    default_repository_class: Happyr\Doctrine\Specification\EntitySpecificationRepository
+    default_repository_class: Happyr\DoctrineSpecification\EntitySpecificationRepository
 ```

--- a/docs/0-1-zend1.md
+++ b/docs/0-1-zend1.md
@@ -1,33 +1,8 @@
 # Integrating with frameworks - Zend 1
 ## Replacing the default repository type
-Doctrine integration with Zend Framework 1 is done manually. However, replacing the default repository type is still simple. In the bootstrap (or wherever Doctrine is configured in the system in question),use Doctrine configruations `setRepositoryFactory` and provide an implementation of `\Doctrine\ORM\Repository\RepositoryFactory`.
+Doctrine integration with Zend Framework 1 is done manually. However, replacing the default repository type is still simple. In the bootstrap (or wherever Doctrine is configured in the system in question), use Doctrine configruations `setRepositoryFactory` method and provide an implementation of `\Doctrine\ORM\Repository\RepositoryFactory`. A basic implementation is provided with `\Happyr\DoctrineSpecification\RepositoryFactory`.
 
 ```php
 // During doctrine configuration
-$config->setRepositoryFactory(new My_Repository_Factory());
-
-// My/Repostiory/Factory.php
-class My_Repository_Factory implements \Doctrine\ORM\RepositoryFactory
-{
-    /**
-     * Gets the repository for an entity class.
-     *
-     * @param \Doctrine\ORM\EntityManagerInterface $entityManager The EntityManager instance.
-     * @param string $entityName The name of the entity.
-     *
-     * @return \Doctrine\Common\Persistence\ObjectRepository
-     */
-    public function getRepository(EntityManagerInterface $entityManager, $entityName)
-    {
-        return new My_Repository_BaseEntitySpecificationRepository($entityManager, $entityManager->getClassMetadata($entityName));
-    }    
-}
-
-// My/Repository/BaseEntitySpecificationRepository
-class My_Repository_BaseEntitySpecificationRepository extends \Happyr\Doctrine\Specification\EntitySpecificationRepository
-{
-    // Implements nothing extra.
-    // Merely provides a concrete instance of \Happyr\Doctrine\Specification\EntitySpecificationRepository
-    // to use with \Happyr\Doctrime\ORM\EntitySpecificationRepositoryFactory
-}
+$config->setRepositoryFactory(new \Happyr\DoctrineSpecification\RepositoryFactory());
 ```

--- a/docs/0-2-zend2.md
+++ b/docs/0-2-zend2.md
@@ -1,32 +1,21 @@
 # Integrating with frameworks - Zend 2
 ## Replacing the default repository type
-Doctrine integration with Zend Framework 2 can be achieved using the `DoctrineORM` bundle. This bundle contains configuration options for the repository factory. To replace the default repository type, provide a concrete implementation of the abstract `\Happyr\Doctrine\Specification\EntitySpecificationRepository` and the necessary configruation options.
+Doctrine integration with Zend Framework 2 can be achieved using the `DoctrineORM` bundle. This bundle contains configuration options for the repository factory. To replace the default repository type, provide a factory creatign an instance of `\Happyr\DoctrineSpecification\EntitySpecificationRepository` and any necessary configruation options.
 
 ```php
-// DoctrineORM bundle configruation
-array(
-   'doctrine' => array(
+// Application configuration
+'doctrine' => array(
+    'configuration' => array(
         'orm_default' => array(
-            'repository_factory' => 'happyr.doctrine.specification.repository'
+            'repository_factory' => 'happyr_doctrinespecification_repository',
         )
     ),
 
     'service_manager' => array(
-        'factories' => array(
-            'happyr.doctrine.specification.repository' => function($sm){
-                return new \My\Repository\BaseEntitySpecificationRepository();   
-            }
+        'services' => array(
+            'happyr_doctrinespecification_repository' => new Happyr\DoctrineSpecification\RepositoryFactory()
         )
     )
 );
-
-// My/Repository/BaseEntitySpecificationRepository.php
-namespace My\Repository;
-
-class BaseEntitySpecificationRepository extends \Happyr\Doctrine\Specification\EntitySpecificationRepository
-{
-    // Implements nothing extra.
-    // Merely provides a concrete instance of \Happyr\Doctrine\Specification\EntitySpecificationRepository
-    // to use with \Happyr\Doctrime\ORM\EntitySpecificationRepositoryFactory
-}
 ```
+    

--- a/docs/0-3-laravel.md
+++ b/docs/0-3-laravel.md
@@ -3,8 +3,8 @@
 If you're choosing to use Doctrine with Laravel, there are some common Doctrine integration packages, however only some of them allow configruation of the default repository type.
 
 ### atrauzzi/laravel-doctrine
-For this package, set the `defaultRepository` setting to `Happyr\Doctrine\Specification\EntitySpecificationRepository`
+For this package, in its configuration settings, set the `defaultRepository` setting to `Happyr\DoctrineSpecification\EntitySpecificationRepository`
 
 ###  mitchellvanw/laravel-doctrine
-For this package, set the `repository` setting to `Happyr\Doctrine\Specification\EntitySpecificationRepository`
+For this package, in its configuration settings, set the `repository` setting to `Happyr\DoctrineSpecification\EntitySpecificationRepository`
 

--- a/src/Happyr/DoctrineSpecification/RepositoryFactory.php
+++ b/src/Happyr/DoctrineSpecification/RepositoryFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Happyr\DoctrineSpecification;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Happyr\DoctrineSpecification\EntitySpecificationRepository;
+
+/**
+ * Factory class for creating \Happyr\DoctrineSpecification\EntitySpecificationRepository instances.
+ *
+ * Provides an implementation of \Doctrine\ORM\Repository\RepositoryFactory so that the
+ * default repository type in Doctrine can easily be replaced.
+ *
+ * @author Andy Hunt
+ */
+class RepositoryFactory implements \Doctrine\ORM\Repository\RepositoryFactory
+{
+    /**
+     * Gets the repository for an entity class.
+     *
+     * @param \Doctrine\ORM\EntityManagerInterface $entityManager The EntityManager instance.
+     * @param string $entityName The name of the entity.
+     *
+     * @return \Doctrine\Common\Persistence\ObjectRepository
+     */
+    public function getRepository(EntityManagerInterface $entityManager, $entityName)
+    {
+        return new EntitySpecificationRepository(
+            $entityManager,
+            $entityManager->getClassMetadata($entityName)
+        );
+    }
+}


### PR DESCRIPTION
Adds guides for replacing the default repository type in Symfony 2, Zend Framwork 1 & 2 and Laravel 4.

I've tested the steps required for ZF 1 & 2 and Laravel. For the Zend Framework family, it turns out that a factory implementation was required, so I've gone ahead included a basic version, in a preliminary place; `\Happyr\DoctrineSpecification\RepositoryFactory`. I figure a basic implementation of it is a worthwhile inclusion, to ease integration with other frameworks.
