### PR TITLE
Changed AbstractQuery to Query. Fixed #40

### DIFF
--- a/spec/Happyr/DoctrineSpecification/EntitySpecificationRepositorySpec.php
+++ b/spec/Happyr/DoctrineSpecification/EntitySpecificationRepositorySpec.php
@@ -2,7 +2,7 @@
 
 namespace spec\Happyr\DoctrineSpecification;
 
-use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\Query;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\Expr;
@@ -31,7 +31,7 @@ class EntitySpecificationRepositorySpec extends ObjectBehavior
         Specification $specification,
         EntityManager $entityManager,
         QueryBuilder $qb,
-        AbstractQuery $query
+        Query $query
     )
     {
         $this->prepareStubs($specification, $entityManager, $qb, $query);
@@ -45,7 +45,7 @@ class EntitySpecificationRepositorySpec extends ObjectBehavior
         Specification $specification,
         EntityManager $entityManager,
         QueryBuilder $qb,
-        AbstractQuery $query,
+        Query $query,
         Modifier $modifier
     )
     {
@@ -57,7 +57,7 @@ class EntitySpecificationRepositorySpec extends ObjectBehavior
         $this->match($specification, $modifier)->shouldReturn($this->result);
     }
 
-    private function prepareStubs(Specification $specification, EntityManager $entityManager, QueryBuilder $qb, AbstractQuery $query)
+    private function prepareStubs(Specification $specification, EntityManager $entityManager, QueryBuilder $qb, Query $query)
     {
         $entityManager->createQueryBuilder()->willReturn($qb);
         $specification->getExpression($qb, $this->alias)->willReturn($this->expression);

--- a/spec/Happyr/DoctrineSpecification/Result/AsArraySpec.php
+++ b/spec/Happyr/DoctrineSpecification/Result/AsArraySpec.php
@@ -2,7 +2,6 @@
 
 namespace spec\Happyr\DoctrineSpecification\Result;
 
-use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\Query;
 use Happyr\DoctrineSpecification\Result\AsArray;
 use Happyr\DoctrineSpecification\Specification;
@@ -24,7 +23,7 @@ class AsArraySpec extends ObjectBehavior
         $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Result\Modifier');
     }
 
-    function it_sets_hydration_mode_to_array(AbstractQuery $query)
+    function it_sets_hydration_mode_to_array(Query $query)
     {
         $query->setHydrationMode(Query::HYDRATE_ARRAY)->shouldBeCalled();
 

--- a/src/Happyr/DoctrineSpecification/Result/AsArray.php
+++ b/src/Happyr/DoctrineSpecification/Result/AsArray.php
@@ -2,7 +2,6 @@
 
 namespace Happyr\DoctrineSpecification\Result;
 
-use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Expr;
 use Happyr\DoctrineSpecification\Specification;
@@ -26,9 +25,9 @@ class AsArray implements Modifier
     }
 
     /**
-     * @param AbstractQuery $query
+     * @param Query $query
      */
-    public function modify(AbstractQuery $query)
+    public function modify(Query $query)
     {
         $query->setHydrationMode(Query::HYDRATE_ARRAY);
     }

--- a/src/Happyr/DoctrineSpecification/Result/Modifier.php
+++ b/src/Happyr/DoctrineSpecification/Result/Modifier.php
@@ -2,12 +2,12 @@
 
 namespace Happyr\DoctrineSpecification\Result;
 
-use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\Query;
 
 interface Modifier
 {
     /**
-     * @param AbstractQuery $query
+     * @param Query $query
      */
-    public function modify(AbstractQuery $query);
+    public function modify(Query $query);
 } 

--- a/src/Happyr/DoctrineSpecification/Result/ModifierCollection.php
+++ b/src/Happyr/DoctrineSpecification/Result/ModifierCollection.php
@@ -2,7 +2,6 @@
 
 namespace Happyr\DoctrineSpecification\Result;
 
-use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\Query;
 use Happyr\DoctrineSpecification\Exception\InvalidArgumentException;
 
@@ -22,9 +21,9 @@ class ModifierCollection implements Modifier
     }
 
     /**
-     * @param AbstractQuery $query
+     * @param Query $query
      */
-    public function modify(AbstractQuery $query)
+    public function modify(Query $query)
     {
         foreach ($this->children as $child) {
             if (!$child instanceof Modifier) {


### PR DESCRIPTION
Since [this](https://github.com/Happyr/Doctrine-Specification/blob/master/src/Happyr/DoctrineSpecification/EntitySpecificationRepository.php#L24) will always return a Query, never a AbstractQuery. 

We should have Query in the library. 
