### PR TITLE
fixed return-value of BaseSpecification::getQueryModifierInstance()

### DIFF
--- a/src/BaseSpecification.php
+++ b/src/BaseSpecification.php
@@ -50,7 +50,7 @@ abstract class BaseSpecification implements Specification
      */
     protected function getQueryModifierInstance()
     {
-        return $this->spec;
+        return null;
     }
 
     /**


### PR DESCRIPTION
I was not able to create something like this, without overwriting getQueryModifierInstance() in "IsActive" Specification.
```php
$this->spec = Spec::andX(
            new IsActive($dqlAlias)
);
```

the reason for that is that BaseSpecification::getQueryModifierInstance() is always returning $this->spec.