### PR TITLE
Make the api simpler

### DIFF
--- a/Upgrade.md
+++ b/Upgrade.md
@@ -15,19 +15,21 @@ It has been many changes since 0.2 and we refactored quite a lot. These are the 
 
 ## Changed interfaces
 
-The old `Specification` interface has been split up to two parts. We got a `Expression` with will modify the `SELECT` clause of
-the SQL query. We also got the `Query\Modifier` interface the modifies the query.
+The old `Specification` interface has been split up to two parts. We got a `Filter` with will modify the `SELECT` clause of
+the SQL query. We also got the `QueryModifier` interface the modifies the query (Limit, Order, Join etc). 
 
-The new `Specification` interface extends `Query\Modifier` and `Expression`.
+The new `Specification` interface extends `Filter` and `QueryModifier`.
 
-You have to update your specifications to comply with `Query\Modifier` and/or `Expression`
+You have to update your specifications to comply with `QueryModifier` and/or `Expression`
 
 
 ## BaseSpecification
 
-There are two new abstract methods `getWrappedModifier` and `getExpression`.
+There are two new methods `getFilter` and `modify`. You don't need to override these. You may use BaseSpecfication as normal. 
+
+The `supports` function has been removed.
 
 ## EntitySpecificationRepository
 
-The `match` method has changed to take a second optional parameter of a `Result\Modifier`. You may modify the result by chnaging
+The `match` method has changed to take a second optional parameter of a `ResultModifier`. You may modify the result by changing
 the hydration mode or to add a cache. We decided that it would not be a part of a `Specification`.

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -1,4 +1,15 @@
-# Upgrade from 0.2 to dev-master
+# Upgrade from 0.3 to dev-master
+
+## BaseSpecification
+
+Merged `getFilterInstance` and `getQueryModifierInstance` into `getSpec`. The new function should return a `Filter` and/or
+a `QueryBuilder`. We did this to make the API easier.
+
+## LogicX
+
+You can now do `Spec::andx(new MyFilter(), new MyQueryModifier);` with both `Filter`s and `QueryBuilder`s.
+
+# Upgrade from 0.2 to 0.3
 
 It has been many changes since 0.2 and we refactored quite a lot. These are the biggest changes.
 

--- a/src/BaseSpecification.php
+++ b/src/BaseSpecification.php
@@ -18,14 +18,6 @@ abstract class BaseSpecification implements Specification
     private $dqlAlias = null;
 
     /**
-     * You may assign a Specification to this property. If you do, you do not *need* to overwrite the getFilterInstance
-     * or getQueryModifierInstance
-     *
-     * @var Specification spec
-     */
-    protected $spec = null;
-
-    /**
      * @param string $dqlAlias
      */
     public function __construct($dqlAlias = null)
@@ -34,23 +26,13 @@ abstract class BaseSpecification implements Specification
     }
 
     /**
-     * This method should return a Filter. You should overwrite this if you're not using BaseSpecification::$spec
+     * Return all the specifications
      *
-     * @return Filter
+     * @return Specification
      */
-    protected function getFilterInstance()
+    protected function getSpec()
     {
-        return $this->spec;
-    }
-
-    /**
-     * This method should return a QueryModifier. You should overwrite this if you're not using BaseSpecification::$spec
-     *
-     * @return QueryModifier
-     */
-    protected function getQueryModifierInstance()
-    {
-        return $this->spec;
+        return;
     }
 
     /**
@@ -61,13 +43,12 @@ abstract class BaseSpecification implements Specification
      */
     public function getFilter(QueryBuilder $qb, $dqlAlias)
     {
-        $this->validate('getFilterInstance', 'Happyr\DoctrineSpecification\Filter\Filter');
-
-        if (null === $filter = $this->getFilterInstance()) {
-            return;
+        $spec = $this->getSpec();
+        if ($spec instanceof Filter) {
+            return $spec->getFilter($qb, $this->getAlias($dqlAlias));
         }
 
-        return $filter->getFilter($qb, $this->getAlias($dqlAlias));
+        return;
     }
 
     /**
@@ -76,34 +57,12 @@ abstract class BaseSpecification implements Specification
      */
     public function modify(QueryBuilder $qb, $dqlAlias)
     {
-        $this->validate('getQueryModifierInstance', 'Happyr\DoctrineSpecification\Query\QueryModifier');
-
-        if (null === $queryModifier = $this->getQueryModifierInstance()) {
-            return;
+        $spec = $this->getSpec();
+        if ($spec instanceof QueryModifier) {
+            return $spec->modify($qb, $this->getAlias($dqlAlias));
         }
 
-        $queryModifier->modify($qb, $this->getAlias($dqlAlias));
-    }
-
-    /**
-     * @param string $getter
-     * @param string $class
-     *
-     * @throws LogicException
-     */
-    private function validate($getter, $class)
-    {
-        $object = $this->$getter();
-        // if $object is an object but not instance of $class
-        if (!is_null($object) && !is_a($object, $class)) {
-            throw new LogicException(sprintf(
-                'Returned object must be an instance of %s. Please validate the %s::%s function and make it return instance of %s.',
-                $class,
-                get_class($this),
-                $getter,
-                $class
-            ));
-        }
+        return;
     }
 
     /**

--- a/src/Logic/LogicX.php
+++ b/src/Logic/LogicX.php
@@ -48,8 +48,10 @@ class LogicX implements Specification
         return call_user_func_array(
             array($qb->expr(), $this->expression),
             array_map(
-                function (Filter $expr) use ($qb, $dqlAlias) {
-                    return $expr->getFilter($qb, $dqlAlias);
+                function ($spec) use ($qb, $dqlAlias) {
+                    if ($spec instanceof Filter) {
+                        return $spec->getFilter($qb, $dqlAlias);
+                    }
                 },
                 $this->children
             )


### PR DESCRIPTION
Made the `BaseSpecification` simpler by removing `getFilterInstance` and `getQueryModifierInstance`. Instead we divide these in `getFilter` and `modify`.

This address the issues in #83 and #84,