### PR TITLE
Added CountOf specification

### DIFF
--- a/src/Spec.php
+++ b/src/Spec.php
@@ -12,12 +12,18 @@ use Happyr\DoctrineSpecification\Filter\IsNull;
 use Happyr\DoctrineSpecification\Logic\LogicX;
 use Happyr\DoctrineSpecification\Logic\Not;
 use Happyr\DoctrineSpecification\Query\Join;
+use Happyr\DoctrineSpecification\Specification\CountOf;
 
 /**
  * Factory class for the specifications
  */
 class Spec
 {
+    public static function countOf(Specification $spec)
+    {
+        return new CountOf($spec);
+    }
+
     public static function andX()
     {
         return new LogicX(LogicX::AND_X, func_get_args());
@@ -92,4 +98,6 @@ class Spec
     {
         return new Like($field, $value, $format, $dqlAlias);
     }
+
+
 }

--- a/src/Specification/CountOf.php
+++ b/src/Specification/CountOf.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Happyr\DoctrineSpecification\Specification;
+
+use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Specification;
+
+/**
+ * @author Tobias Nyholm
+ */
+class CountOf implements Specification
+{
+    /**
+     * @var \Happyr\DoctrineSpecification\Specification child
+     */
+    private $child;
+
+    /**
+     * @param Specification $child
+     */
+    public function __construct(Specification $child)
+    {
+        $this->child = $child;
+    }
+
+    public function getFilter(QueryBuilder $qb, $dqlAlias)
+    {
+        $qb->select(sprintf('COUNT(%s)', $dqlAlias));
+
+        return $this->child->getFilter($qb, $dqlAlias);
+    }
+
+    public function modify(QueryBuilder $qb, $dqlAlias)
+    {
+        $this->child->modify($qb, $dqlAlias);
+    }
+}


### PR DESCRIPTION
This will address the issue in #80. 

Question: Do we really want to host complete `Specification`s like this?