### PR TITLE
Making the API more fluent

### DIFF
--- a/src/Logic/AndX.php
+++ b/src/Logic/AndX.php
@@ -8,4 +8,22 @@ class AndX extends LogicX
     {
         parent::__construct(self::AND_X, func_get_args());
     }
+
+    /**
+     * Append an other specification with a logic AND.
+     *
+     * <code>
+     * $spec = Spec::andX(A, B);
+     * $spec->andX(C);
+     *
+     * // We be the same as
+     * $spec = Spec::andX(A, B, C);
+     * </code>
+     *
+     * @param |Happyr\DoctrineSpecification\Filter\Filter|\Happyr\DoctrineSpecification\Query\QueryModifier $child
+     */
+    public function andX($child)
+    {
+        $this->append($child);
+    }
 }

--- a/src/Logic/LogicX.php
+++ b/src/Logic/LogicX.php
@@ -16,7 +16,7 @@ class LogicX implements Specification
     const OR_X = 'orX';
 
     /**
-     * @var Filter[] children
+     * @var Filter[]|QueryModifier[] children
      */
     private $children;
 
@@ -28,10 +28,10 @@ class LogicX implements Specification
     /**
      * Take two or more Expression as parameters.
      *
-     * @param string   $expression
-     * @param Filter[] $children
+     * @param string                   $expression
+     * @param Filter[]|QueryModifier[] $children
      */
-    public function __construct($expression, array $children)
+    public function __construct($expression, array $children = array())
     {
         $this->expression = $expression;
         $this->children = $children;
@@ -69,5 +69,15 @@ class LogicX implements Specification
                 $child->modify($query, $dqlAlias);
             }
         }
+    }
+
+    /**
+     * Add another child to this logic tree.
+     *
+     * @param |Happyr\DoctrineSpecification\Filter\Filter|\Happyr\DoctrineSpecification\Query\QueryModifier $child
+     */
+    protected function append($child)
+    {
+        $this->children[] = $child;
     }
 }

--- a/src/Logic/OrX.php
+++ b/src/Logic/OrX.php
@@ -8,4 +8,22 @@ class OrX extends LogicX
     {
         parent::__construct(self::OR_X, func_get_args());
     }
+
+    /**
+     * Append an other specification with a logic OR.
+     *
+     * <code>
+     * $spec = Spec::orX(A, B);
+     * $spec->orX(C);
+     *
+     * // We be the same as
+     * $spec = Spec::orX(A, B, C);
+     * </code>
+     *
+     * @param |Happyr\DoctrineSpecification\Filter\Filter|\Happyr\DoctrineSpecification\Query\QueryModifier $child
+     */
+    public function orX($child)
+    {
+        $this->append($child);
+    }
 }


### PR DESCRIPTION
A PR for the discussion in #45. 

Makes sure you can do something like: 

```php
public function search($parameters)
{
    $spec = Spec::andX();
    // ... If foo is set
    $spec->andX(Spec::eq("foo", $parameters["foo"]);
    // ... If bar is set
    $spec->andX(Spec::eq("bar", $parameters["bar"]);

    $finalSpec = Spec::orX(
        $spec,
        Spec::andX(Spec::lt("fizz", 4), Spec::eq("bing", 3))
    );
    $finalSpec->orX(Spec::gt("buzz", 99));
}

// Logic tree:
// (foo && bar) || (fizz && bing) || buzz
```

``` php
$spec = (Spec::AndX(A))->andX(B)->andX(C);
```