### PR TITLE
Moved Specification interface to Specification folder

### DIFF
--- a/src/BaseSpecification.php
+++ b/src/BaseSpecification.php
@@ -5,6 +5,7 @@ namespace Happyr\DoctrineSpecification;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Filter\Filter;
 use Happyr\DoctrineSpecification\Query\QueryModifier;
+use Happyr\DoctrineSpecification\Specification\Specification;
 
 /**
  * Extend this abstract class if you want to build a new spec with your domain logic.

--- a/src/EntitySpecificationRepositoryTrait.php
+++ b/src/EntitySpecificationRepositoryTrait.php
@@ -2,6 +2,8 @@
 
 namespace Happyr\DoctrineSpecification;
 
+use Happyr\DoctrineSpecification\Specification\Specification;
+
 /**
  * This trait should be used by a class extending \Doctrine\ORM\EntityRepository.
  */

--- a/src/Logic/LogicX.php
+++ b/src/Logic/LogicX.php
@@ -5,7 +5,7 @@ namespace Happyr\DoctrineSpecification\Logic;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Filter\Filter;
 use Happyr\DoctrineSpecification\Query\QueryModifier;
-use Happyr\DoctrineSpecification\Specification;
+use Happyr\DoctrineSpecification\Specification\Specification;
 
 /**
  * This class should be used when you combine two or more Expressions.

--- a/src/Logic/Not.php
+++ b/src/Logic/Not.php
@@ -5,7 +5,7 @@ namespace Happyr\DoctrineSpecification\Logic;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Filter\Filter;
 use Happyr\DoctrineSpecification\Query\QueryModifier;
-use Happyr\DoctrineSpecification\Specification;
+use Happyr\DoctrineSpecification\Specification\Specification;
 
 class Not implements Specification
 {

--- a/src/Spec.php
+++ b/src/Spec.php
@@ -20,6 +20,7 @@ use Happyr\DoctrineSpecification\Logic\Not;
 use Happyr\DoctrineSpecification\Query\Join;
 use Happyr\DoctrineSpecification\Result\Cache;
 use Happyr\DoctrineSpecification\Specification\CountOf;
+use Happyr\DoctrineSpecification\Specification\Specification;
 
 /**
  * Factory class for the specifications.

--- a/src/Specification/CountOf.php
+++ b/src/Specification/CountOf.php
@@ -3,7 +3,6 @@
 namespace Happyr\DoctrineSpecification\Specification;
 
 use Doctrine\ORM\QueryBuilder;
-use Happyr\DoctrineSpecification\Specification;
 
 /**
  * @author Tobias Nyholm
@@ -11,7 +10,7 @@ use Happyr\DoctrineSpecification\Specification;
 class CountOf implements Specification
 {
     /**
-     * @var \Happyr\DoctrineSpecification\Specification child
+     * @var \Happyr\DoctrineSpecification\Specification\Specification child
      */
     private $child;
 

--- a/src/Specification/Specification.php
+++ b/src/Specification/Specification.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Happyr\DoctrineSpecification;
+namespace Happyr\DoctrineSpecification\Specification;
 
 use Happyr\DoctrineSpecification\Filter\Filter;
 use Happyr\DoctrineSpecification\Query\QueryModifier;

--- a/tests/EntitySpecificationRepositorySpec.php
+++ b/tests/EntitySpecificationRepositorySpec.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\EntitySpecificationRepository;
 use Happyr\DoctrineSpecification\Result\ResultModifier;
-use Happyr\DoctrineSpecification\Specification;
+use Happyr\DoctrineSpecification\Specification\Specification;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 

--- a/tests/Filter/LikeSpec.php
+++ b/tests/Filter/LikeSpec.php
@@ -22,7 +22,7 @@ class LikeSpec extends ObjectBehavior
 
     public function it_is_a_specification()
     {
-        $this->shouldHaveType('Happyr\DoctrineSpecification\Specification');
+        $this->shouldHaveType('Happyr\DoctrineSpecification\Specification\Specification');
     }
 
     public function it_surrounds_with_wildcards_when_using_contains(QueryBuilder $qb, ArrayCollection $parameters)

--- a/tests/Logic/LogicXSpec.php
+++ b/tests/Logic/LogicXSpec.php
@@ -6,7 +6,7 @@ use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Filter\Filter;
 use Happyr\DoctrineSpecification\Logic\LogicX;
-use Happyr\DoctrineSpecification\Specification;
+use Happyr\DoctrineSpecification\Specification\Specification;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -24,7 +24,7 @@ class LogicXSpec extends ObjectBehavior
 
     function it_is_a_specification()
     {
-        $this->shouldHaveType('Happyr\DoctrineSpecification\Specification');
+        $this->shouldHaveType('Happyr\DoctrineSpecification\Specification\Specification');
     }
 
     function it_modifies_all_child_queries(QueryBuilder $queryBuilder, Specification $specificationA, Specification $specificationB)

--- a/tests/Logic/NotSpec.php
+++ b/tests/Logic/NotSpec.php
@@ -7,7 +7,7 @@ use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Filter\Filter;
 use Happyr\DoctrineSpecification\Logic\Not;
 use Happyr\DoctrineSpecification\Spec;
-use Happyr\DoctrineSpecification\Specification;
+use Happyr\DoctrineSpecification\Specification\Specification;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 

--- a/tests/Result/AsArraySpec.php
+++ b/tests/Result/AsArraySpec.php
@@ -5,7 +5,7 @@ namespace tests\Happyr\DoctrineSpecification\Result;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\Query;
 use Happyr\DoctrineSpecification\Result\AsArray;
-use Happyr\DoctrineSpecification\Specification;
+use Happyr\DoctrineSpecification\Specification\Specification;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 


### PR DESCRIPTION
Since we now got a folder named "Specification" we should move the `Specification` interface into it. This makes us consistent with the Filter, QueryModifier and ResultModifer interfaces. 

This is a BC break and the namespace will be awfully long (`Happyr\DoctrineSpecification\Specification\Specification`). Developers will, however, not use that namespace when they write their application code. 

I want to have some input on this PR before I merge it.