### PR TITLE
Removed abstract signature to be compliant with doctrine/orm 2.5

### DIFF
--- a/src/EntitySpecificationRepositoryTrait.php
+++ b/src/EntitySpecificationRepositoryTrait.php
@@ -13,13 +13,6 @@ trait EntitySpecificationRepositoryTrait
     private $alias = 'e';
 
     /**
-     * @param $alias
-     *
-     * @return \Doctrine\ORM\QueryBuilder
-     */
-    abstract public function createQueryBuilder($alias);
-
-    /**
      * Get result when you match with a Specification.
      *
      * @param Specification         $specification

--- a/tests/EntitySpecificationRepositorySpec.php
+++ b/tests/EntitySpecificationRepositorySpec.php
@@ -61,7 +61,7 @@ class EntitySpecificationRepositorySpec extends ObjectBehavior
     {
         $entityManager->createQueryBuilder()->willReturn($qb);
         $specification->getFilter($qb, $this->alias)->willReturn($this->expression);
-        $qb->from(Argument::any(), $this->alias)->willReturn($qb);
+        $qb->from(Argument::any(), $this->alias, null)->willReturn($qb);
         $qb->select($this->alias)->willReturn($qb);
         $qb->where($this->expression)->willReturn($qb);
         $qb->getQuery()->willReturn($query);


### PR DESCRIPTION
In doctrine/orm master they have changed the signature. We need to remove this line to be compliant to all versions of doctrine. ([Source](https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/EntityRepository.php#L79))