### PR TITLE
Added prepare function to return a Query

### DIFF
--- a/src/EntitySpecificationRepositoryTrait.php
+++ b/src/EntitySpecificationRepositoryTrait.php
@@ -2,6 +2,7 @@
 
 namespace Happyr\DoctrineSpecification;
 
+use Doctrine\ORM\Query;
 use Happyr\DoctrineSpecification\Specification\Specification;
 
 /**
@@ -24,6 +25,21 @@ trait EntitySpecificationRepositoryTrait
      */
     public function match(Specification $specification, Result\ResultModifier $modifier = null)
     {
+        $query = $this->prepare($specification, $modifier);
+
+        return $query->execute();
+    }
+
+    /**
+     * Prepare a Query with a Specification
+     *
+     * @param Specification         $specification
+     * @param Result\ResultModifier $modifier
+     *
+     * @return Query
+     */
+    public function prepare(Specification $specification, Result\ResultModifier $modifier = null)
+    {
         $alias = $this->alias;
         $qb = $this->createQueryBuilder($alias);
 
@@ -32,9 +48,11 @@ trait EntitySpecificationRepositoryTrait
 
         if ($modifier !== null) {
             $modifier->modify($query);
+
+            return $query;
         }
 
-        return $query->execute();
+        return $query;
     }
 
     /**

--- a/src/EntitySpecificationRepositoryTrait.php
+++ b/src/EntitySpecificationRepositoryTrait.php
@@ -25,7 +25,7 @@ trait EntitySpecificationRepositoryTrait
      */
     public function match(Specification $specification, Result\ResultModifier $modifier = null)
     {
-        $query = $this->prepare($specification, $modifier);
+        $query = $this->getQuery($specification, $modifier);
 
         return $query->execute();
     }
@@ -38,7 +38,7 @@ trait EntitySpecificationRepositoryTrait
      *
      * @return Query
      */
-    public function prepare(Specification $specification, Result\ResultModifier $modifier = null)
+    public function getQuery(Specification $specification, Result\ResultModifier $modifier = null)
     {
         $alias = $this->alias;
         $qb = $this->createQueryBuilder($alias);


### PR DESCRIPTION
This address the issue in #85. This will add support for paginator.

```php
$spec = MySpec();
$query=$repo->prepare($spec);
$paginator = new Paginator($query);
```

As discussed in [this issue](https://github.com/rikbruil/Doctrine-Specification/issues/2); returning a Query will allow more flexibility but letting `match`-function return the query moves the responsibility to retrieve data up to the service layer. 

Please give me comments on this PR. How about the name of this function? I was also considering `getQuery`. 