### PR TITLE
[#110] Add Spec::asSingleScalar and rewrite Spec::asSingle

### DIFF
--- a/src/Result/AsSingleScalar.php
+++ b/src/Result/AsSingleScalar.php
@@ -6,15 +6,15 @@ use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\Query;
 
 /**
- * Class AsSingle.
+ * Class AsSingleScalar.
  */
-class AsSingle implements ResultModifier
+class AsSingleScalar implements ResultModifier
 {
     /**
      * @param AbstractQuery $query
      */
     public function modify(AbstractQuery $query)
     {
-        $query->setHydrationMode(Query::HYDRATE_OBJECT);
+        $query->setHydrationMode(Query::HYDRATE_SINGLE_SCALAR);
     }
 }

--- a/src/Spec.php
+++ b/src/Spec.php
@@ -19,6 +19,7 @@ use Happyr\DoctrineSpecification\Filter\IsNull;
 use Happyr\DoctrineSpecification\Logic\LogicX;
 use Happyr\DoctrineSpecification\Logic\Not;
 use Happyr\DoctrineSpecification\Query\Join;
+use Happyr\DoctrineSpecification\Result\AsSingleScalar;
 use Happyr\DoctrineSpecification\Result\Cache;
 use Happyr\DoctrineSpecification\Specification\CountOf;
 use Happyr\DoctrineSpecification\Specification\Having;
@@ -99,6 +100,11 @@ class Spec
     public static function asSingle()
     {
         return new AsSingle();
+    }
+
+    public static function asSingleScalar()
+    {
+        return new AsSingleScalar();
     }
 
     public static function cache($cacheLifetime)

--- a/tests/Result/AsSingleScalarSpec.php
+++ b/tests/Result/AsSingleScalarSpec.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace tests\Happyr\DoctrineSpecification\Result;
+
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\Query;
+use Happyr\DoctrineSpecification\Result\AsSingleScalar;
+use Happyr\DoctrineSpecification\Specification\Specification;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+/**
+ * @mixin AsSingleScalar
+ */
+class AsSingleScalarSpec extends ObjectBehavior
+{
+    function it_is_a_result_modifier()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Result\ResultModifier');
+    }
+
+    function it_sets_hydration_mode_to_single_scalar(AbstractQuery $query)
+    {
+        $query->setHydrationMode(Query::HYDRATE_SINGLE_SCALAR)->shouldBeCalled();
+
+        $this->modify($query);
+    }
+}

--- a/tests/Result/AsSingleSpec.php
+++ b/tests/Result/AsSingleSpec.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace tests\Happyr\DoctrineSpecification\Result;
+
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\Query;
+use Happyr\DoctrineSpecification\Result\AsSingle;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+/**
+ * @mixin AsSingle
+ */
+class AsSingleSpec extends ObjectBehavior
+{
+    function it_is_a_result_modifier()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Result\ResultModifier');
+    }
+
+    function it_sets_hydration_mode_to_object(AbstractQuery $query)
+    {
+        $query->setHydrationMode(Query::HYDRATE_OBJECT)->shouldBeCalled();
+
+        $this->modify($query);
+    }
+}


### PR DESCRIPTION
This PR relates to https://github.com/Happyr/Doctrine-Specification/issues/110#issuecomment-107951347

I'm pretty sure `Query::HYDRATE_OBJECT` is the one we'd want for `Spec::asSingle`, right? 