### PR TITLE
Make EntitySpecificationRepository accept specs not creating a filter

### DIFF
--- a/src/EntitySpecificationRepositoryTrait.php
+++ b/src/EntitySpecificationRepositoryTrait.php
@@ -43,7 +43,12 @@ trait EntitySpecificationRepositoryTrait
         $qb = $this->createQueryBuilder($alias);
 
         $specification->modify($qb, $alias);
-        $query = $qb->where($specification->getFilter($qb, $alias))->getQuery();
+
+        if ($filter = (string) $specification->getFilter($qb, $alias)) {
+            $qb->where($filter);
+        }
+
+        $query = $qb->getQuery();
 
         if ($modifier !== null) {
             $modifier->modify($query);

--- a/tests/EntitySpecificationRepositorySpec.php
+++ b/tests/EntitySpecificationRepositorySpec.php
@@ -27,6 +27,22 @@ class EntitySpecificationRepositorySpec extends ObjectBehavior
         $this->beConstructedWith($entityManager, $classMetadata);
     }
 
+    function it_matches_a_specification_with_empty_filter(
+        Specification $specification,
+        EntityManager $entityManager,
+        QueryBuilder $qb,
+        AbstractQuery $query
+    )
+    {
+        $this->prepareEntityManagerStub($entityManager, $qb);
+        $this->prepareQueryBuilderStub($qb, $query);
+        $query->execute()->willReturn($this->result);
+
+        $qb->where()->shouldNotBeCalled();
+
+        $this->match($specification)->shouldReturn($this->result);
+    }
+
     function it_matches_a_specification_without_result_modifier(
         Specification $specification,
         EntityManager $entityManager,
@@ -59,8 +75,23 @@ class EntitySpecificationRepositorySpec extends ObjectBehavior
 
     private function prepareStubs(Specification $specification, EntityManager $entityManager, QueryBuilder $qb, AbstractQuery $query)
     {
+        $this->prepareEntityManagerStub($entityManager, $qb);
+        $this->prepareSpecificationStub($specification, $qb);
+        $this->prepareQueryBuilderStub($qb, $query);
+    }
+
+    private function prepareEntityManagerStub(EntityManager $entityManager, QueryBuilder $qb)
+    {
         $entityManager->createQueryBuilder()->willReturn($qb);
+    }
+
+    private function prepareSpecificationStub(Specification $specification, QueryBuilder $qb)
+    {
         $specification->getFilter($qb, $this->alias)->willReturn($this->expression);
+    }
+
+    private function prepareQueryBuilderStub(QueryBuilder $qb, Query $query)
+    {
         $qb->from(Argument::any(), $this->alias, null)->willReturn($qb);
         $qb->select($this->alias)->willReturn($qb);
         $qb->where($this->expression)->willReturn($qb);


### PR DESCRIPTION
Hey!

Ran into a small problem today. If a specification won't generate a filter (i.e. returns `null`) then the query builder will generate DQL with broken syntax:

    SELECT e FROM Foo\Bar e WHERE

So a simple fix is to just check whether an expression was generated or not.

Cheers,
Kristen