### PR TITLE
Support for Join conditions

### DIFF
--- a/src/Spec.php
+++ b/src/Spec.php
@@ -59,19 +59,19 @@ class Spec
      * Query modifier
      */
 
-    public static function join($field, $newAlias, $dqlAlias = null)
+    public static function join($field, $newAlias, $dqlAlias = null, $condition = null, $conditionType = null)
     {
-        return new Join($field, $newAlias, $dqlAlias);
+        return new Join($field, $newAlias, $dqlAlias, $condition, $conditionType);
     }
 
-    public static function leftJoin($field, $newAlias, $dqlAlias = null)
+    public static function leftJoin($field, $newAlias, $dqlAlias = null, $condition = null, $conditionType = null)
     {
-        return new LeftJoin($field, $newAlias, $dqlAlias);
+        return new LeftJoin($field, $newAlias, $dqlAlias, $condition, $conditionType);
     }
 
-    public static function innerJoin($field, $newAlias, $dqlAlias = null)
+    public static function innerJoin($field, $newAlias, $dqlAlias = null, $condition = null, $conditionType = null)
     {
-        return new InnerJoin($field, $newAlias, $dqlAlias);
+        return new InnerJoin($field, $newAlias, $dqlAlias, $condition, $conditionType);
     }
 
     public static function limit($count)

--- a/tests/Query/InnerJoinSpec.php
+++ b/tests/Query/InnerJoinSpec.php
@@ -22,14 +22,14 @@ class InnerJoinSpec extends ObjectBehavior
 
     public function it_joins_with_default_dql_alias(QueryBuilder $qb)
     {
-        $qb->innerJoin('a.user', 'authUser')->shouldBeCalled();
+        $qb->innerJoin('a.user', 'authUser', null, null)->shouldBeCalled();
         $this->modify($qb, 'a');
     }
 
     public function it_uses_local_alias_if_global_was_not_set(QueryBuilder $qb)
     {
         $this->beConstructedWith('user', 'authUser');
-        $qb->innerJoin('b.user', 'authUser')->shouldBeCalled();
+        $qb->innerJoin('b.user', 'authUser', null, null)->shouldBeCalled();
         $this->modify($qb, 'b');
     }
 }

--- a/tests/Query/JoinSpec.php
+++ b/tests/Query/JoinSpec.php
@@ -3,7 +3,9 @@
 namespace tests\Happyr\DoctrineSpecification\Query;
 
 use Doctrine\ORM\QueryBuilder;
+use Doctrine\ORM\Query\Expr;
 use Happyr\DoctrineSpecification\Query\Join;
+use Happyr\DoctrineSpecification\Filter;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -23,14 +25,52 @@ class JoinSpec extends ObjectBehavior
 
     public function it_joins_with_default_dql_alias(QueryBuilder $qb)
     {
-        $qb->join('a.user', 'authUser')->shouldBeCalled();
+        $qb->join('a.user', 'authUser', null, null)->shouldBeCalled();
         $this->modify($qb, 'a');
     }
 
     public function it_uses_local_alias_if_global_was_not_set(QueryBuilder $qb)
     {
         $this->beConstructedWith('user', 'authUser');
-        $qb->join('b.user', 'authUser')->shouldBeCalled();
+        $qb->join('b.user', 'authUser', null, null)->shouldBeCalled();
         $this->modify($qb, 'b');
     }
+
+    public function it_joins_with_simple_condition(QueryBuilder $qb)
+    {
+        $this->beConstructedWith('user', 'authUser', null, 'authUser.enabled = true');
+        $qb->join('b.user', 'authUser', 'WITH', 'authUser.enabled = true')->shouldBeCalled();
+        $this->modify($qb, 'b');
+    }
+
+    public function it_joins_with_array_of_simple_conditions(QueryBuilder $qb, Expr $expr, Expr\Andx $andX)
+    {
+        $this->beConstructedWith('user', 'authUser', null, [
+            'authUser.enabled = true',
+            'authUser.active = false'
+        ]);
+
+        $qb->expr()->willReturn($expr);
+        $expr->andX(
+            'authUser.enabled = true',
+            'authUser.active = false'
+        )->willReturn($andX);
+
+        $qb->join('b.user', 'authUser', 'WITH', $andX)->shouldBeCalled();
+
+        $this->modify($qb, 'b');
+    }
+
+    public function it_joins_with_filter_condition(QueryBuilder $qb, Filter\Equals $spec)
+    {
+        $spec->beConstructedWith(['enabled', 'true']);
+        $this->beConstructedWith('user', 'authUser', null, $spec);
+
+        $spec->getFilter($qb, 'authUser')->shouldBeCalled();
+        $spec->getFilter($qb, 'authUser')->willReturn('authUser.enabled = true');
+        $qb->join('b.user', 'authUser', 'WITH', 'authUser.enabled = true')->shouldBeCalled();
+
+        $this->modify($qb, 'b');
+    }
+    
 }

--- a/tests/Query/LeftJoinSpec.php
+++ b/tests/Query/LeftJoinSpec.php
@@ -20,13 +20,13 @@ class LeftJoinSpec extends ObjectBehavior
     }
     public function it_joins_with_default_dql_alias(QueryBuilder $qb)
     {
-        $qb->leftJoin('a.user', 'authUser')->shouldBeCalled();
+        $qb->leftJoin('a.user', 'authUser', null, null)->shouldBeCalled();
         $this->modify($qb, 'a');
     }
     public function it_uses_local_alias_if_global_was_not_set(QueryBuilder $qb)
     {
         $this->beConstructedWith('user', 'authUser');
-        $qb->leftJoin('b.user', 'authUser')->shouldBeCalled();
+        $qb->leftJoin('b.user', 'authUser', null, null)->shouldBeCalled();
         $this->modify($qb, 'b');
     }
 }


### PR DESCRIPTION
This:

``` php
Spec::join('users', 'user', null, Spec::andx(
    Spec::eq('active', true),
    Spec::eq('status', 'somestatus')
))
```

Will be equivalent to:

``` php
$qb->join('foo.users', 'user', 'WITH', $qb->expr()->andX(
    $qb->expr()->eq('user.active',  true),
    $qb->expr()->eq('user.status', 'somestatus')
));
```
