### PR TITLE
Add support ValueObject for Comparison filter

### DIFF
--- a/src/DBALTypesResolver.php
+++ b/src/DBALTypesResolver.php
@@ -7,6 +7,14 @@ use Doctrine\DBAL\Types\Type;
 abstract class DBALTypesResolver
 {
     /**
+     * The map of supported doctrine mapping types.
+     *
+     * @var array
+     */
+    private static $_typesMap = array(
+    );
+
+    /**
      * Try get type for value.
      *
      * If type is not found return NULL.
@@ -18,8 +26,14 @@ abstract class DBALTypesResolver
     public static function tryGetTypeForValue($value)
     {
         if (is_object($value)) { // maybe it's a ValueObject
+            // try get type name from types map
+            $className = get_class($value);
+            if (isset(self::$_typesMap[$className])) {
+                return Type::getType(self::$_typesMap[$className]);
+            }
+
             // use class name as type name
-            $classNameParts = explode('\\', get_class($value));
+            $classNameParts = explode('\\', $className);
             $typeName = array_pop($classNameParts);
 
             if (array_key_exists($typeName, Type::getTypesMap())) {
@@ -28,5 +42,18 @@ abstract class DBALTypesResolver
         }
 
         return null;
+    }
+
+    /**
+     * Adds a custom type to the type map for resolve Value Object.
+     *
+     * @param string $name      The name of the type.
+     * @param string $className The class name of the Value Object.
+     *
+     * @return void
+     */
+    public static function addType($name, $className)
+    {
+        self::$_typesMap[$className] = $name;
     }
 }

--- a/src/DBALTypesResolver.php
+++ b/src/DBALTypesResolver.php
@@ -24,20 +24,24 @@ final class DBALTypesResolver
      */
     public static function tryGetTypeForValue($value)
     {
-        if (is_object($value)) { // maybe it's a ValueObject
-            // try get type name from types map
-            $className = get_class($value);
-            if (isset(self::$typesMap[$className])) {
-                return Type::getType(self::$typesMap[$className]);
-            }
+        if (!is_object($value)) {
+            return null;
+        }
 
-            // use class name as type name
-            $classNameParts = explode('\\', $className);
-            $typeName = array_pop($classNameParts);
+        // maybe it's a ValueObject
 
-            if (array_key_exists($typeName, Type::getTypesMap())) {
-                return Type::getType($typeName);
-            }
+        // try get type name from types map
+        $className = get_class($value);
+        if (isset(self::$typesMap[$className])) {
+            return Type::getType(self::$typesMap[$className]);
+        }
+
+        // use class name as type name
+        $classNameParts = explode('\\', $className);
+        $typeName = array_pop($classNameParts);
+
+        if (array_key_exists($typeName, Type::getTypesMap())) {
+            return Type::getType($typeName);
         }
 
         return null;

--- a/src/DBALTypesResolver.php
+++ b/src/DBALTypesResolver.php
@@ -11,8 +11,7 @@ final class DBALTypesResolver
      *
      * @var array
      */
-    private static $_typesMap = array(
-    );
+    private static $typesMap = array();
 
     /**
      * Try get type for value.
@@ -28,8 +27,8 @@ final class DBALTypesResolver
         if (is_object($value)) { // maybe it's a ValueObject
             // try get type name from types map
             $className = get_class($value);
-            if (isset(self::$_typesMap[$className])) {
-                return Type::getType(self::$_typesMap[$className]);
+            if (isset(self::$typesMap[$className])) {
+                return Type::getType(self::$typesMap[$className]);
             }
 
             // use class name as type name
@@ -52,6 +51,6 @@ final class DBALTypesResolver
      */
     public static function addType($name, $className)
     {
-        self::$_typesMap[$className] = $name;
+        self::$typesMap[$className] = $name;
     }
 }

--- a/src/DBALTypesResolver.php
+++ b/src/DBALTypesResolver.php
@@ -4,7 +4,7 @@ namespace Happyr\DoctrineSpecification;
 
 use Doctrine\DBAL\Types\Type;
 
-abstract class DBALTypesResolver
+final class DBALTypesResolver
 {
     /**
      * The map of supported doctrine mapping types.

--- a/src/DBALTypesResolver.php
+++ b/src/DBALTypesResolver.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Happyr\DoctrineSpecification;
+
+use Doctrine\DBAL\Types\Type;
+
+abstract class DBALTypesResolver
+{
+    /**
+     * Try get type for value.
+     *
+     * If type is not found return NULL.
+     *
+     * @param mixed $value
+     *
+     * @return Type|null
+     */
+    public static function tryGetTypeForValue($value)
+    {
+        if (is_object($value)) { // maybe it's a ValueObject
+            // use class name as type name
+            $classNameParts = explode('\\', get_class($value));
+            $typeName = array_pop($classNameParts);
+
+            if (array_key_exists($typeName, Type::getTypesMap())) {
+                return Type::getType($typeName);
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/DBALTypesResolver.php
+++ b/src/DBALTypesResolver.php
@@ -47,10 +47,8 @@ abstract class DBALTypesResolver
     /**
      * Adds a custom type to the type map for resolve Value Object.
      *
-     * @param string $name      The name of the type.
-     * @param string $className The class name of the Value Object.
-     *
-     * @return void
+     * @param string $name      the name of the type.
+     * @param string $className the class name of the Value Object.
      */
     public static function addType($name, $className)
     {

--- a/src/DBALTypesResolver.php
+++ b/src/DBALTypesResolver.php
@@ -47,8 +47,8 @@ abstract class DBALTypesResolver
     /**
      * Adds a custom type to the type map for resolve Value Object.
      *
-     * @param string $name      the name of the type.
-     * @param string $className the class name of the Value Object.
+     * @param string $name      the name of the type
+     * @param string $className the class name of the Value Object
      */
     public static function addType($name, $className)
     {

--- a/src/Filter/Comparison.php
+++ b/src/Filter/Comparison.php
@@ -93,12 +93,23 @@ class Comparison implements Filter
 
         if (is_scalar($this->value)) {
             $qb->setParameter($paramName, $this->value);
-        } elseif (is_object($this->value) && method_exists($this->value, '__toString')) { // is ValueObject
-            $qb->setParameter($paramName, (string) $this->value);
+
+        } elseif (is_object($this->value)) { // is ValueObject
+            /**
+             * This works only if class name is equal type name
+             * If type name is wrong throw exception
+             * @see Type::getType()
+             */
+            $class_name_parts = explode('\\', get_class($this->value));
+            $type_name = array_pop($class_name_parts);
+            $value = $qb->getEntityManager()->getConnection()->convertToDatabaseValue($this->value, $type_name);
+
+            $qb->setParameter($paramName, $value);
+
         } else {
             throw new InvalidArgumentException(sprintf(
                 'Imposable use the value of type "%s" as query parameter.',
-                is_object($this->value) ? get_class($this->value) : gettype($this->value)
+                gettype($this->value)
             ));
         }
 

--- a/src/Filter/Comparison.php
+++ b/src/Filter/Comparison.php
@@ -91,7 +91,7 @@ class Comparison implements Filter
 
         $paramName = $this->getParameterName($qb);
 
-        if (is_scalar($this->value)) {
+        if (is_scalar($this->value) || $this->value instanceof \DateTime || $this->value instanceof \DateInterval) {
             $qb->setParameter($paramName, $this->value);
         } elseif (is_object($this->value)) { // is ValueObject
             /**

--- a/src/Filter/Comparison.php
+++ b/src/Filter/Comparison.php
@@ -93,11 +93,11 @@ class Comparison implements Filter
 
         if (is_scalar($this->value)) {
             $qb->setParameter($paramName, $this->value);
-
         } elseif (is_object($this->value)) { // is ValueObject
             /**
-             * This works only if class name is equal type name
-             * If type name is wrong throw exception
+             * This works only if class name is equal type name.
+             * If type name is wrong throw exception.
+             *
              * @see Type::getType()
              */
             $class_name_parts = explode('\\', get_class($this->value));
@@ -105,7 +105,6 @@ class Comparison implements Filter
             $value = $qb->getEntityManager()->getConnection()->convertToDatabaseValue($this->value, $type_name);
 
             $qb->setParameter($paramName, $value);
-
         } else {
             throw new InvalidArgumentException(sprintf(
                 'Imposable use the value of type "%s" as query parameter.',

--- a/src/Filter/Comparison.php
+++ b/src/Filter/Comparison.php
@@ -4,8 +4,8 @@ namespace Happyr\DoctrineSpecification\Filter;
 
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Query\Expr\Comparison as DoctrineComparison;
-use Happyr\DoctrineSpecification\DBALTypesResolver;
 use Happyr\DoctrineSpecification\Exception\InvalidArgumentException;
+use Happyr\DoctrineSpecification\ValueConverter;
 
 /**
  * Comparison class.
@@ -90,17 +90,8 @@ class Comparison implements Filter
             $dqlAlias = $this->dqlAlias;
         }
 
-        $value = $this->value;
-
-        if ($type = DBALTypesResolver::tryGetTypeForValue($this->value)) {
-            $value = $type->convertToDatabaseValue(
-                $value,
-                $qb->getEntityManager()->getConnection()->getDatabasePlatform()
-            );
-        }
-
         $paramName = $this->getParameterName($qb);
-        $qb->setParameter($paramName, $value);
+        $qb->setParameter($paramName, ValueConverter::convertToDatabaseValue($this->value, $qb));
 
         return (string) new DoctrineComparison(
             sprintf('%s.%s', $dqlAlias, $this->field),

--- a/src/Filter/Comparison.php
+++ b/src/Filter/Comparison.php
@@ -95,11 +95,11 @@ class Comparison implements Filter
 
         if (is_object($this->value)) { // maybe it's a ValueObject
             // try get type name from class name
-            $class_name_parts = explode('\\', get_class($this->value));
-            $type_name = array_pop($class_name_parts);
+            $classNameParts = explode('\\', get_class($this->value));
+            $typeName = array_pop($classNameParts);
 
-            if (array_key_exists($type_name, Type::getTypesMap())) {
-                $value = $qb->getEntityManager()->getConnection()->convertToDatabaseValue($value, $type_name);
+            if (array_key_exists($typeName, Type::getTypesMap())) {
+                $value = $qb->getEntityManager()->getConnection()->convertToDatabaseValue($value, $typeName);
             }
         }
 

--- a/src/Filter/Comparison.php
+++ b/src/Filter/Comparison.php
@@ -94,7 +94,7 @@ class Comparison implements Filter
         if (is_scalar($this->value)) {
             $qb->setParameter($paramName, $this->value);
         } elseif (is_object($this->value) && method_exists($this->value, '__toString')) { // is ValueObject
-            $qb->setParameter($paramName, (string)$this->value);
+            $qb->setParameter($paramName, (string) $this->value);
         } else {
             throw new InvalidArgumentException(sprintf(
                 'Imposable use the value of type "%s" as query parameter.',

--- a/src/Filter/Comparison.php
+++ b/src/Filter/Comparison.php
@@ -97,7 +97,7 @@ class Comparison implements Filter
             $qb->setParameter($paramName, (string)$this->value);
         } else {
             throw new InvalidArgumentException(sprintf(
-                'Imposable use value ov type "%s" us as query parameter.',
+                'Imposable use the value of type "%s" as query parameter.',
                 is_object($this->value) ? get_class($this->value) : gettype($this->value)
             ));
         }

--- a/src/Filter/In.php
+++ b/src/Filter/In.php
@@ -3,6 +3,7 @@
 namespace Happyr\DoctrineSpecification\Filter;
 
 use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\ValueConverter;
 
 class In implements Filter
 {
@@ -47,8 +48,17 @@ class In implements Filter
             $dqlAlias = $this->dqlAlias;
         }
 
+        $value = $this->value;
+        if (is_array($value)) {
+            foreach ($value as $k => $v) {
+                $value[$k] = ValueConverter::convertToDatabaseValue($v, $qb);
+            }
+        } else {
+            $value = ValueConverter::convertToDatabaseValue($value, $qb);
+        }
+
         $paramName = $this->getParameterName($qb);
-        $qb->setParameter($paramName, $this->value);
+        $qb->setParameter($paramName, $value);
 
         return (string) $qb->expr()->in(
             sprintf('%s.%s', $dqlAlias, $this->field),

--- a/src/ValueConverter.php
+++ b/src/ValueConverter.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Happyr\DoctrineSpecification;
+
+use Doctrine\ORM\QueryBuilder;
+
+abstract class ValueConverter
+{
+    /**
+     * @param mixed        $value
+     * @param QueryBuilder $qb
+     *
+     * @return mixed
+     */
+    public static function convertToDatabaseValue($value, QueryBuilder $qb)
+    {
+        if ($type = DBALTypesResolver::tryGetTypeForValue($value)) {
+            return $type->convertToDatabaseValue(
+                $value,
+                $qb->getEntityManager()->getConnection()->getDatabasePlatform()
+            );
+        }
+
+        return $value;
+    }
+}

--- a/src/ValueConverter.php
+++ b/src/ValueConverter.php
@@ -4,7 +4,7 @@ namespace Happyr\DoctrineSpecification;
 
 use Doctrine\ORM\QueryBuilder;
 
-abstract class ValueConverter
+final class ValueConverter
 {
     /**
      * @param mixed        $value


### PR DESCRIPTION
Fix for #133

[ValueObject](https://en.wikipedia.org/wiki/Value_object) must have `__toString()` method for convert it to query parameter.

Example usage:

```php
use MabeEnum\Enum;

class UserStatus extends Enum
{
    const INACTIVE = 'i';
    const ACTIVE   = 'a';
    const DELETED  = 'd';
}
```

In spec 

```php
Spec::eq('status', UserStatus::ACTIVE());
```

**PS:** I not add tests for this solution becos i don't know how to use `phpspec`. Sorry