### PR TITLE
Add Slice query modifier

### DIFF
--- a/src/Query/Slice.php
+++ b/src/Query/Slice.php
@@ -7,15 +7,15 @@ use Happyr\DoctrineSpecification\Logic\AndX;
 class Slice extends AndX
 {
     /**
-     * @param int $slice_size
-     * @param int $slice_number
+     * @param int $sliceSize
+     * @param int $sliceNumber
      */
-    public function __construct($slice_size, $slice_number = 1)
+    public function __construct($sliceSize, $sliceNumber = 1)
     {
-        if ($slice_number > 1) {
-            parent::__construct(new Limit($slice_size), new Offset(($slice_number - 1) * $slice_size));
+        if ($sliceNumber > 1) {
+            parent::__construct(new Limit($sliceSize), new Offset(($sliceNumber - 1) * $sliceSize));
         } else {
-            parent::__construct(new Limit($slice_size));
+            parent::__construct(new Limit($sliceSize));
         }
     }
 }

--- a/src/Query/Slice.php
+++ b/src/Query/Slice.php
@@ -2,20 +2,40 @@
 
 namespace Happyr\DoctrineSpecification\Query;
 
-use Happyr\DoctrineSpecification\Logic\AndX;
+use Doctrine\ORM\QueryBuilder;
 
-class Slice extends AndX
+class Slice implements QueryModifier
 {
+    /**
+     * @var int
+     */
+    private $sliceSize;
+
+    /**
+     * @var int
+     */
+    private $sliceNumber = 1;
+
     /**
      * @param int $sliceSize
      * @param int $sliceNumber
      */
     public function __construct($sliceSize, $sliceNumber = 1)
     {
-        if ($sliceNumber > 1) {
-            parent::__construct(new Limit($sliceSize), new Offset(($sliceNumber - 1) * $sliceSize));
-        } else {
-            parent::__construct(new Limit($sliceSize));
+        $this->sliceSize = $sliceSize;
+        $this->sliceNumber = $sliceNumber;
+    }
+
+    /**
+     * @param QueryBuilder $qb
+     * @param string       $dqlAlias
+     */
+    public function modify(QueryBuilder $qb, $dqlAlias)
+    {
+        $qb->setMaxResults($this->sliceSize);
+
+        if ($this->sliceNumber > 1) {
+            $qb->setFirstResult(($this->sliceNumber - 1) * $this->sliceSize);
         }
     }
 }

--- a/src/Query/Slice.php
+++ b/src/Query/Slice.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Happyr\DoctrineSpecification\Query;
+
+use Happyr\DoctrineSpecification\Logic\AndX;
+
+class Slice extends AndX
+{
+    /**
+     * @param int $slice_size
+     * @param int $slice_number
+     */
+    public function __construct($slice_size, $slice_number = 1)
+    {
+        if ($slice_number > 1) {
+            parent::__construct(new Limit($slice_size), new Offset(($slice_number - 1) * $slice_size));
+        } else {
+            parent::__construct(new Limit($slice_size));
+        }
+    }
+}

--- a/src/Query/Slice.php
+++ b/src/Query/Slice.php
@@ -14,13 +14,13 @@ class Slice implements QueryModifier
     /**
      * @var int
      */
-    private $sliceNumber = 1;
+    private $sliceNumber = 0;
 
     /**
      * @param int $sliceSize
      * @param int $sliceNumber
      */
-    public function __construct($sliceSize, $sliceNumber = 1)
+    public function __construct($sliceSize, $sliceNumber = 0)
     {
         $this->sliceSize = $sliceSize;
         $this->sliceNumber = $sliceNumber;
@@ -34,8 +34,8 @@ class Slice implements QueryModifier
     {
         $qb->setMaxResults($this->sliceSize);
 
-        if ($this->sliceNumber > 1) {
-            $qb->setFirstResult(($this->sliceNumber - 1) * $this->sliceSize);
+        if ($this->sliceNumber > 0) {
+            $qb->setFirstResult($this->sliceNumber * $this->sliceSize);
         }
     }
 }

--- a/src/Spec.php
+++ b/src/Spec.php
@@ -134,7 +134,7 @@ class Spec
      *
      * @return Slice
      */
-    public static function Slice($sliceSize, $sliceNumber = 1)
+    public static function slice($sliceSize, $sliceNumber = 1)
     {
         return new Slice($sliceSize, $sliceNumber);
     }

--- a/src/Spec.php
+++ b/src/Spec.php
@@ -134,7 +134,7 @@ class Spec
      *
      * @return Slice
      */
-    public static function slice($sliceSize, $sliceNumber = 1)
+    public static function slice($sliceSize, $sliceNumber = 0)
     {
         return new Slice($sliceSize, $sliceNumber);
     }

--- a/src/Spec.php
+++ b/src/Spec.php
@@ -19,6 +19,7 @@ use Happyr\DoctrineSpecification\Query\LeftJoin;
 use Happyr\DoctrineSpecification\Query\Limit;
 use Happyr\DoctrineSpecification\Query\Offset;
 use Happyr\DoctrineSpecification\Query\OrderBy;
+use Happyr\DoctrineSpecification\Query\Slice;
 use Happyr\DoctrineSpecification\Result\AsArray;
 use Happyr\DoctrineSpecification\Result\AsSingleScalar;
 use Happyr\DoctrineSpecification\Result\Cache;
@@ -125,6 +126,17 @@ class Spec
     public static function offset($count)
     {
         return new Offset($count);
+    }
+
+    /**
+     * @param int $slice_size
+     * @param int $slice_number
+     *
+     * @return Slice
+     */
+    public static function Slice($slice_size, $slice_number = 1)
+    {
+        return new Slice($slice_size, $slice_number);
     }
 
     /**

--- a/src/Spec.php
+++ b/src/Spec.php
@@ -129,14 +129,14 @@ class Spec
     }
 
     /**
-     * @param int $slice_size
-     * @param int $slice_number
+     * @param int $sliceSize
+     * @param int $sliceNumber
      *
      * @return Slice
      */
-    public static function Slice($slice_size, $slice_number = 1)
+    public static function Slice($sliceSize, $sliceNumber = 1)
     {
-        return new Slice($slice_size, $slice_number);
+        return new Slice($sliceSize, $sliceNumber);
     }
 
     /**

--- a/tests/Filter/SliceSpec.php
+++ b/tests/Filter/SliceSpec.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace tests\Happyr\DoctrineSpecification\Query;
+
+use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Query\Slice;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @mixin Slice
+ */
+class SliceSpec extends ObjectBehavior
+{
+    /**
+     * @var int
+     */
+    private $sliceSize = 25;
+
+    public function let()
+    {
+        $this->beConstructedWith($this->sliceSize, 0);
+    }
+
+    public function it_is_a_specification()
+    {
+        $this->shouldHaveType('Happyr\DoctrineSpecification\Query\QueryModifier');
+    }
+
+    public function it_slice_with_zero_index(QueryBuilder $qb)
+    {
+        $this->beConstructedWith($this->sliceSize, 0);
+
+        $qb->setMaxResults($this->sliceSize)->shouldBeCalled();
+
+        $this->modify($qb, 'a');
+    }
+
+    public function it_slice_with_second_index(QueryBuilder $qb)
+    {
+        $sliceNumber = 1;
+
+        $this->beConstructedWith($this->sliceSize, $sliceNumber);
+
+        $qb->setMaxResults($this->sliceSize)->shouldBeCalled();
+        $qb->setFirstResult($this->sliceSize * $sliceNumber)->shouldBeCalled();
+
+        $this->modify($qb, 'a');
+    }
+}


### PR DESCRIPTION
Simplified scheme for dividing the query result into slices.

Before:

```php
$perPage = 20;
$currentPage = 2;

$videos = $rep->match(Spec::andX(
    new VideoPublished(),
    Spec::limit($perPage),
    Spec::offset(($currentPage - 1) * $perPage)
);
```

After:

```php
$perPage = 20;
$currentPage = 2;

$videos = $rep->match(Spec::andX(
    new VideoPublished(),
    Spec::slice($perPage, $currentPage)
);
```