### PR TITLE
Сorrect param for CountOf specification

### DIFF
--- a/src/Spec.php
+++ b/src/Spec.php
@@ -19,12 +19,12 @@ use Happyr\DoctrineSpecification\Query\LeftJoin;
 use Happyr\DoctrineSpecification\Query\Limit;
 use Happyr\DoctrineSpecification\Query\Offset;
 use Happyr\DoctrineSpecification\Query\OrderBy;
+use Happyr\DoctrineSpecification\Query\QueryModifier;
 use Happyr\DoctrineSpecification\Result\AsArray;
 use Happyr\DoctrineSpecification\Result\AsSingleScalar;
 use Happyr\DoctrineSpecification\Result\Cache;
 use Happyr\DoctrineSpecification\Specification\CountOf;
 use Happyr\DoctrineSpecification\Specification\Having;
-use Happyr\DoctrineSpecification\Specification\Specification;
 
 /**
  * Factory class for the specifications.
@@ -333,11 +333,11 @@ class Spec
      */
 
     /**
-     * @param Specification $spec
+     * @param Filter[]|QueryModifier[] $spec
      *
      * @return CountOf
      */
-    public static function countOf(Specification $spec)
+    public static function countOf($spec)
     {
         return new CountOf($spec);
     }

--- a/src/Spec.php
+++ b/src/Spec.php
@@ -333,7 +333,7 @@ class Spec
      */
 
     /**
-     * @param Filter[]|QueryModifier[] $spec
+     * @param Filter|QueryModifier $spec
      *
      * @return CountOf
      */

--- a/src/Specification/CountOf.php
+++ b/src/Specification/CountOf.php
@@ -12,12 +12,12 @@ use Happyr\DoctrineSpecification\Query\QueryModifier;
 class CountOf implements Specification
 {
     /**
-     * @var Filter[]|QueryModifier[] child
+     * @var Filter|QueryModifier child
      */
     private $child;
 
     /**
-     * @param Filter[]|QueryModifier[] $child
+     * @param Filter|QueryModifier $child
      */
     public function __construct($child)
     {

--- a/src/Specification/CountOf.php
+++ b/src/Specification/CountOf.php
@@ -3,6 +3,8 @@
 namespace Happyr\DoctrineSpecification\Specification;
 
 use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Filter\Filter;
+use Happyr\DoctrineSpecification\Query\QueryModifier;
 
 /**
  * @author Tobias Nyholm
@@ -10,14 +12,14 @@ use Doctrine\ORM\QueryBuilder;
 class CountOf implements Specification
 {
     /**
-     * @var Specification child
+     * @var Filter[]|QueryModifier[] child
      */
     private $child;
 
     /**
-     * @param Specification $child
+     * @param Filter[]|QueryModifier[] $child
      */
-    public function __construct(Specification $child)
+    public function __construct($child)
     {
         $this->child = $child;
     }
@@ -32,7 +34,11 @@ class CountOf implements Specification
     {
         $qb->select(sprintf('COUNT(%s)', $dqlAlias));
 
-        return $this->child->getFilter($qb, $dqlAlias);
+        if ($this->child instanceof Filter) {
+            return $this->child->getFilter($qb, $dqlAlias);
+        }
+
+        return '';
     }
 
     /**
@@ -41,6 +47,8 @@ class CountOf implements Specification
      */
     public function modify(QueryBuilder $qb, $dqlAlias)
     {
-        $this->child->modify($qb, $dqlAlias);
+        if ($this->child instanceof QueryModifier) {
+            $this->child->modify($qb, $dqlAlias);
+        }
     }
 }

--- a/tests/Specification/CountOfSpec.php
+++ b/tests/Specification/CountOfSpec.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace tests\Happyr\DoctrineSpecification\Specification;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Filter\Equals;
+use Happyr\DoctrineSpecification\Query\GroupBy;
+use Happyr\DoctrineSpecification\Specification\CountOf;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @mixin CountOf
+ */
+class CountOfSpec extends ObjectBehavior
+{
+    public function let()
+    {
+        $this->beConstructedWith(null);
+    }
+
+    public function it_is_a_specification()
+    {
+        $this->shouldHaveType('Happyr\DoctrineSpecification\Specification\Specification');
+    }
+
+    public function it_count_of_all(QueryBuilder $qb)
+    {
+        $dqlAlias = 'a';
+
+        $qb->select(sprintf('COUNT(%s)', $dqlAlias))->shouldBeCalled();
+
+        $this->getFilter($qb, $dqlAlias)->shouldBe('');
+        $this->modify($qb, $dqlAlias);
+    }
+
+    public function it_count_of_all_grouped_by_id(QueryBuilder $qb)
+    {
+        $field = 'id';
+        $dqlAlias = 'a';
+
+        $this->beConstructedWith(new GroupBy($field, $dqlAlias));
+
+        $qb->select(sprintf('COUNT(%s)', $dqlAlias))->shouldBeCalled();
+        $qb->addGroupBy(sprintf('%s.%s', $dqlAlias, $field))->shouldBeCalled();
+
+        $this->getFilter($qb, $dqlAlias)->shouldBe('');
+        $this->modify($qb, $dqlAlias);
+    }
+
+    public function it_count_of_all_with_group_is_foo(QueryBuilder $qb)
+    {
+        $field = 'group';
+        $value = 'foo';
+        $dqlAlias = 'a';
+        $parameters_count = 0;
+        $paramName = 'comparison_'.$parameters_count;
+
+        $this->beConstructedWith(new Equals($field, $value, $dqlAlias));
+
+        $qb->select(sprintf('COUNT(%s)', $dqlAlias))->shouldBeCalled();
+        $qb->getParameters()->willReturn(new ArrayCollection());
+        $qb->setParameter($paramName, $value)->shouldBeCalled();
+
+        $this->getFilter($qb, $dqlAlias)->shouldBe(sprintf('%s.%s = :%s', $dqlAlias, $field, $paramName));
+        $this->modify($qb, $dqlAlias);
+    }
+}


### PR DESCRIPTION
Fix for #145 

Available use the filters as specification

```php
$total = (int) $rep->match(
    Spec::сountOf(
        Spec::eq('user', $user->getId()
    ),
    new AsSingleScalar()
);
```

Available сount of all entities

```php
$total = (int) $rep->match(
    Spec::сountOf(null),
    new AsSingleScalar()
);
```