### PR TITLE
Added support for index by and changing selection set

### DIFF
--- a/src/Query/AbstractSelectionSet.php
+++ b/src/Query/AbstractSelectionSet.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Happyr\DoctrineSpecification\Query;
+
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * Class AbstractSelectionSet.
+ */
+abstract class AbstractSelectionSet implements QueryModifier
+{
+    /**
+     * Field names.
+     *
+     * @var string[]
+     */
+    private $fields;
+
+    /**
+     * DQL Alias.
+     *
+     * @var string
+     */
+    private $dqlAlias;
+
+    /**
+     * SelectionSet constructor.
+     *
+     * @param string[]|string $fields   List of fields or map entityField -> resultField
+     * @param string|null     $dqlAlias DQL alias
+     */
+    public function __construct($fields, $dqlAlias = null)
+    {
+        $this->fields = (array) $fields;
+        $this->dqlAlias = $dqlAlias;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    final public function modify(QueryBuilder $qb, $dqlAlias)
+    {
+        if (null !== $this->dqlAlias) {
+            $dqlAlias = $this->dqlAlias;
+        }
+
+        $fields = $this->getSelection($dqlAlias);
+
+        $this->modifySelection($fields, $qb);
+    }
+
+    /**
+     * Modify selection set in given query builder.
+     *
+     * @param string[]     $fields Prepared set of fields
+     * @param QueryBuilder $qb     Query builder object
+     *
+     * @return mixed
+     */
+    abstract protected function modifySelection(array $fields, QueryBuilder $qb);
+
+    /**
+     * Return fields selection.
+     *
+     * @param string $dqlAlias DQL alias
+     *
+     * @return array
+     */
+    private function getSelection($dqlAlias)
+    {
+        $result = [];
+        foreach ($this->fields as $k => $v) {
+            $isAliased = is_string($k) && is_string($v);
+            $fieldName = $isAliased ? $k : $v;
+
+            list($fieldAlias, $fieldName) = explode('.', $fieldName, 2) + [null, null];
+            if (null === $fieldName) {
+                $fieldName = $fieldAlias;
+                $fieldAlias = $dqlAlias;
+            }
+
+            $result[] = $isAliased ? sprintf('%s.%s AS %s', $fieldAlias, $fieldName, $v) :
+                sprintf('%s.%s', $fieldAlias, $fieldName);
+        }
+
+        return $result;
+    }
+}

--- a/src/Query/AddSelectionSet.php
+++ b/src/Query/AddSelectionSet.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Happyr\DoctrineSpecification\Query;
+
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * Class SelectionSet.
+ */
+class AddSelectionSet extends AbstractSelectionSet
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function modifySelection(array $fields, QueryBuilder $qb)
+    {
+        $qb->addSelect($fields);
+    }
+}

--- a/src/Query/IndexBy.php
+++ b/src/Query/IndexBy.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Happyr\DoctrineSpecification\Query;
+
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * Class IndexBy.
+ */
+class IndexBy implements QueryModifier
+{
+    /**
+     * Field name.
+     *
+     * @var string
+     */
+    private $field;
+
+    /**
+     * DQL Alias.
+     *
+     * @var string
+     */
+    private $dqlAlias;
+
+    /**
+     * IndexBy constructor.
+     *
+     * @param string $field    Field name for indexing
+     * @param string $dqlAlias DQL alias of field
+     */
+    public function __construct($field, $dqlAlias = null)
+    {
+        $this->field = $field;
+        $this->dqlAlias = $dqlAlias;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function modify(QueryBuilder $qb, $dqlAlias)
+    {
+        if (null !== $this->dqlAlias) {
+            $dqlAlias = $this->dqlAlias;
+        }
+
+        $qb->indexBy($dqlAlias, sprintf('%s.%s', $dqlAlias, $this->field));
+    }
+}

--- a/src/Query/SelectionSet.php
+++ b/src/Query/SelectionSet.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Happyr\DoctrineSpecification\Query;
+
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * Class SelectionSet.
+ */
+class SelectionSet extends AbstractSelectionSet
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function modifySelection(array $fields, QueryBuilder $qb)
+    {
+        $qb->select($fields);
+    }
+}

--- a/src/Spec.php
+++ b/src/Spec.php
@@ -12,13 +12,16 @@ use Happyr\DoctrineSpecification\Filter\Like;
 use Happyr\DoctrineSpecification\Logic\AndX;
 use Happyr\DoctrineSpecification\Logic\Not;
 use Happyr\DoctrineSpecification\Logic\OrX;
+use Happyr\DoctrineSpecification\Query\AddSelectionSet;
 use Happyr\DoctrineSpecification\Query\GroupBy;
+use Happyr\DoctrineSpecification\Query\IndexBy;
 use Happyr\DoctrineSpecification\Query\InnerJoin;
 use Happyr\DoctrineSpecification\Query\Join;
 use Happyr\DoctrineSpecification\Query\LeftJoin;
 use Happyr\DoctrineSpecification\Query\Limit;
 use Happyr\DoctrineSpecification\Query\Offset;
 use Happyr\DoctrineSpecification\Query\OrderBy;
+use Happyr\DoctrineSpecification\Query\SelectionSet;
 use Happyr\DoctrineSpecification\Query\QueryModifier;
 use Happyr\DoctrineSpecification\Query\Slice;
 use Happyr\DoctrineSpecification\Result\AsArray;
@@ -107,6 +110,39 @@ class Spec
     public static function innerJoin($field, $newAlias, $dqlAlias = null)
     {
         return new InnerJoin($field, $newAlias, $dqlAlias);
+    }
+
+    /**
+     * @param string $field
+     * @param string $dqlAlias
+     *
+     * @return IndexBy
+     */
+    public static function indexBy($field, $dqlAlias = null)
+    {
+        return new IndexBy($field, $dqlAlias);
+    }
+
+    /**
+     * @param string[]|string $fields
+     * @param null            $dqlAlias
+     *
+     * @return SelectionSet
+     */
+    public static function selectionSet($fields, $dqlAlias = null)
+    {
+        return new SelectionSet($fields, $dqlAlias);
+    }
+
+    /**
+     * @param string[]|string $fields
+     * @param null            $dqlAlias
+     *
+     * @return AddSelectionSet
+     */
+    public static function addSelectionSet($fields, $dqlAlias = null)
+    {
+        return new AddSelectionSet($fields, $dqlAlias);
     }
 
     /**

--- a/tests/Query/AddSelectionSetSpec.php
+++ b/tests/Query/AddSelectionSetSpec.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace tests\Happyr\DoctrineSpecification\Query;
+
+use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Query\AddSelectionSet;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @mixin AddSelectionSet
+ */
+class AddSelectionSetSpec extends ObjectBehavior
+{
+    public function let()
+    {
+        $this->beConstructedWith('field');
+    }
+
+    public function it_is_a_result_modifier()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Query\QueryModifier');
+    }
+
+    public function it_adds_selection(QueryBuilder $qb)
+    {
+        $qb->select(['f.first', 'f.second']);
+        $this->beConstructedWith(['thing', 'another']);
+        $qb->addSelect(['f.thing', 'f.another'])->shouldBeCalled();
+        $this->modify($qb, 'f');
+    }
+
+    public function it_respects_foreign_dql_alias(QueryBuilder $qb)
+    {
+        $this->beConstructedWith(['thing', 'd.another']);
+        $qb->addSelect(['f.thing', 'd.another'])->shouldBeCalled();
+        $this->modify($qb, 'f');
+    }
+
+    public function it_supports_fields_aliasing(QueryBuilder $qb)
+    {
+        $this->beConstructedWith(['thing', 'd.another' => 'ret']);
+        $qb->addSelect(['f.thing', 'd.another AS ret'])->shouldBeCalled();
+        $this->modify($qb, 'f');
+    }
+
+    public function it_supports_fields_aliasing_for_own_fields(QueryBuilder $qb)
+    {
+        $this->beConstructedWith(['thing' => 'ret', 'd.another']);
+        $qb->addSelect(['f.thing AS ret', 'd.another'])->shouldBeCalled();
+        $this->modify($qb, 'f');
+    }
+
+    public function it_uses_own_dql_alias(QueryBuilder $qb)
+    {
+        $this->beConstructedWith(['thing' => 'ret', 'd.another'], 'x');
+        $qb->addSelect(['x.thing AS ret', 'd.another'])->shouldBeCalled();
+        $this->modify($qb, 'f');
+    }
+
+    public function it_can_recognize_aliased_embedded_object(QueryBuilder $qb)
+    {
+        $this->beConstructedWith(['thing', 'd.embedded.field' => 'ret']);
+        $qb->addSelect(['f.thing', 'd.embedded.field AS ret'])->shouldBeCalled();
+        $this->modify($qb, 'f');
+    }
+}

--- a/tests/Query/IndexBySpec.php
+++ b/tests/Query/IndexBySpec.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace tests\Happyr\DoctrineSpecification\Query;
+
+use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Query\IndexBy;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @mixin IndexBy
+ */
+class IndexBySpec extends ObjectBehavior
+{
+    private $field = 'the_field';
+
+    private $alias = 'f';
+
+    public function let()
+    {
+        $this->beConstructedWith($this->field, $this->alias);
+    }
+
+    public function it_is_a_result_modifier()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Query\QueryModifier');
+    }
+
+    public function it_indexes_with_default_dql_alias(QueryBuilder $qb)
+    {
+        $this->beConstructedWith('something', 'x');
+        $qb->indexBy('x', 'x.something')->shouldBeCalled();
+        $this->modify($qb, 'a');
+    }
+
+    public function it_uses_local_alias_if_global_was_not_set(QueryBuilder $qb)
+    {
+        $this->beConstructedWith('thing');
+        $qb->indexBy('b', 'b.thing')->shouldBeCalled();
+        $this->modify($qb, 'b');
+    }
+}

--- a/tests/Query/SelectionSetSpec.php
+++ b/tests/Query/SelectionSetSpec.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace tests\Happyr\DoctrineSpecification\Query;
+
+use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Query\SelectionSet;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @mixin SelectionSet
+ */
+class SelectionSetSpec extends ObjectBehavior
+{
+    public function let()
+    {
+        $this->beConstructedWith('field');
+    }
+
+    public function it_is_a_result_modifier()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Query\QueryModifier');
+    }
+
+    public function it_accepts_string_for_fields(QueryBuilder $qb)
+    {
+        $this->beConstructedWith('field');
+        $qb->select(['f.field'])->shouldBeCalled();
+        $this->modify($qb, 'f');
+    }
+
+    public function it_accepts_array_for_fields(QueryBuilder $qb)
+    {
+        $this->beConstructedWith(['thing', 'another']);
+        $qb->select(['f.thing', 'f.another'])->shouldBeCalled();
+        $this->modify($qb, 'f');
+    }
+
+    public function it_replaces_selection_when_replace_flag_is_set(QueryBuilder $qb)
+    {
+        $qb->select(['f.bad_field', 'f.another_bad_field']);
+        $this->beConstructedWith(['thing', 'another']);
+        $qb->select(['f.thing', 'f.another'])->shouldBeCalled();
+        $this->modify($qb, 'f');
+    }
+
+    public function it_uses_own_dql_alias(QueryBuilder $qb)
+    {
+        $this->beConstructedWith(['thing' => 'ret', 'd.another'], 'x');
+        $qb->select(['x.thing AS ret', 'd.another'])->shouldBeCalled();
+        $this->modify($qb, 'f');
+    }
+
+    public function it_can_recognize_aliased_embedded_object(QueryBuilder $qb)
+    {
+        $this->beConstructedWith(['thing', 'd.embedded.field' => 'ret']);
+        $qb->select(['f.thing', 'd.embedded.field AS ret'])->shouldBeCalled();
+        $this->modify($qb, 'f');
+    }
+}


### PR DESCRIPTION
This PR adds two new specifications with features and resolves #155 :
1. Support for indexing results by some field:
```
Spec::andX(
  Speс::indexBy('thing');
);
```
2. Adding fields to selection set
```
Spec::andX(
  Spec::addSelectionSet(['my_field', 'x.another_field'])
);
```
3. Replacing selection set with new one
```
Spec::andX(
  Spec::selectionSet(['my_field' , 'x.another_field'])
);
```
4. Aliasing selection set
```
Spec::andX(
  Spec::selectionSet(['my_field' => 'retVal' ])
);
```

```
Spec::andX(
  Spec::addSelectionSet(['my_field' => 'retVal' ])
);
```