### PR TITLE
Add method for get QueryBuilder by spec

### DIFF
--- a/src/EntitySpecificationRepositoryInterface.php
+++ b/src/EntitySpecificationRepositoryInterface.php
@@ -2,11 +2,11 @@
 
 namespace Happyr\DoctrineSpecification;
 
+use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Filter\Filter;
 use Happyr\DoctrineSpecification\Query\QueryModifier;
 use Happyr\DoctrineSpecification\Result\ResultModifier;
-use Doctrine\ORM\Query;
-use Doctrine\ORM\QueryBuilder;
 
 /**
  * This interface should be used by an EntityRepository implementing the Specification pattern.

--- a/src/EntitySpecificationRepositoryInterface.php
+++ b/src/EntitySpecificationRepositoryInterface.php
@@ -64,5 +64,5 @@ interface EntitySpecificationRepositoryInterface
      *
      * @return QueryBuilder
      */
-    public function getQueryBuilder($specification, $alias = null)
+    public function getQueryBuilder($specification, $alias = null);
 }

--- a/src/EntitySpecificationRepositoryInterface.php
+++ b/src/EntitySpecificationRepositoryInterface.php
@@ -5,6 +5,8 @@ namespace Happyr\DoctrineSpecification;
 use Happyr\DoctrineSpecification\Filter\Filter;
 use Happyr\DoctrineSpecification\Query\QueryModifier;
 use Happyr\DoctrineSpecification\Result\ResultModifier;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
 
 /**
  * This interface should be used by an EntityRepository implementing the Specification pattern.
@@ -52,7 +54,15 @@ interface EntitySpecificationRepositoryInterface
      * @param Filter|QueryModifier $specification
      * @param ResultModifier       $modifier
      *
-     * @return \Doctrine\ORM\Query
+     * @return Query
      */
     public function getQuery($specification, ResultModifier $modifier);
+
+    /**
+     * @param Filter|QueryModifier $specification
+     * @param string|null          $alias
+     *
+     * @return QueryBuilder
+     */
+    public function getQueryBuilder($specification, $alias = null)
 }

--- a/src/EntitySpecificationRepositoryTrait.php
+++ b/src/EntitySpecificationRepositoryTrait.php
@@ -4,6 +4,7 @@ namespace Happyr\DoctrineSpecification;
 
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
+use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Filter\Filter;
 use Happyr\DoctrineSpecification\Query\QueryModifier;
@@ -83,7 +84,7 @@ trait EntitySpecificationRepositoryTrait
      * @param Filter|QueryModifier $specification
      * @param ResultModifier       $modifier
      *
-     * @return \Doctrine\ORM\Query
+     * @return Query
      */
     public function getQuery($specification, ResultModifier $modifier = null)
     {
@@ -96,6 +97,20 @@ trait EntitySpecificationRepositoryTrait
         }
 
         return $query;
+    }
+
+    /**
+     * @param Filter|QueryModifier $specification
+     * @param string|null          $alias
+     *
+     * @return QueryBuilder
+     */
+    public function getQueryBuilder($specification, $alias = null)
+    {
+        $qb = $this->createQueryBuilder($alias ?: $this->getAlias());
+        $this->applySpecification($qb, $specification, $alias);
+
+        return $qb;
     }
 
     /**


### PR DESCRIPTION
Definition
====

Specifications describe the business rules and now we can use it only for selections.
It is not possible to use specifications for queries for updating and deletion of entities.
We are forced to duplicate the conditions.

Usage
====

Select only one field of entity by specification

```php
$country = $rep
    ->getQueryBuilder(Spec::andX(
        Spec::neq('country', '')
        Spec::limit(1)
    ), 'v')
    ->select('v.country')
    ->getQuery()
    ->getSingleScalarResult()
;
```

Update entities by specification

```php
$rep
    ->getQueryBuilder(Spec::eq('country', ''))
    ->update(null, 'v')
    ->set('v.country', ':country')
    ->setParameter('country', $country)
    ->getQuery()
    ->execute()
;
```

Delete entities by specification (#152)

```php
$rep
    ->getQueryBuilder($spec)
    ->delete()
    ->getQuery()
    ->execute()
;
```