### PR TITLE
Remove double implementation of doctrine interfaces

### DIFF
--- a/src/EntitySpecificationRepository.php
+++ b/src/EntitySpecificationRepository.php
@@ -3,13 +3,11 @@
 namespace Happyr\DoctrineSpecification;
 
 use Doctrine\ORM\EntityRepository;
-use Doctrine\Common\Collections\Selectable;
-use Doctrine\Common\Persistence\ObjectRepository;
 
 /**
  * This class allows you to use a Specification to query entities.
  */
-class EntitySpecificationRepository extends EntityRepository implements EntitySpecificationRepositoryInterface, ObjectRepository, Selectable
+class EntitySpecificationRepository extends EntityRepository implements EntitySpecificationRepositoryInterface
 {
     use EntitySpecificationRepositoryTrait;
 }


### PR DESCRIPTION
We don't need to reimplement explicitly these two interfaces in this concrete class because it extends `EntityRepository` which already implements them. So the new contract from https://github.com/Happyr/Doctrine-Specification/pull/134 is already satisfied in this class.