### PR TITLE
Implementation of Selection concept

### DIFF
--- a/docs/0-usage.md
+++ b/docs/0-usage.md
@@ -252,3 +252,13 @@ Spec::select(Spec::selectAs(
     'discount'
 ))
 ```
+
+Use aliases in conditions to search a cheap products:
+
+```php
+// DQL: SELECT e.price_current price FROM ... WHERE price < :low_cost_limit
+Spec::andX(
+    Spec::select(Spec::selectAs('price_current', 'price')),
+    Spec::lt(Spec::alias('price'), $low_cost_limit)
+)
+```

--- a/docs/0-usage.md
+++ b/docs/0-usage.md
@@ -189,3 +189,32 @@ $spec = Spec::gt('day', Spec::value($day, Type::DATE));
 // DQL: e.day IN (:days)
 $spec = Spec::in('day', Spec::values($days, Type::DATE));
 ```
+
+# Customize selection
+
+Sometimes we need to customize the selection. To do this, we can use `select` and `addSelect` query modifiers. Example
+of selection single field:
+
+```php
+// DQL: SELECT e.email FROM ...
+Spec::select('email')
+// or
+Spec::select(Spec::field('email'))
+```
+
+Add single field in the selected set:
+
+```php
+// DQL: SELECT e, u.email FROM ...
+Spec::addSelect(Spec::field('email', $dqlAlias))
+```
+
+Add one more custom fields in the selected set:
+
+```php
+// DQL: SELECT e.title, e.cover, u.name, u.avatar FROM ...
+Spec::andX(
+    Spec::select('title', 'cover'),
+    Spec::addSelect(Spec::field('name', $dqlAlias), Spec::field('avatar', $dqlAlias))
+)
+```

--- a/docs/0-usage.md
+++ b/docs/0-usage.md
@@ -218,3 +218,10 @@ Spec::andX(
     Spec::addSelect(Spec::field('name', $dqlAlias), Spec::field('avatar', $dqlAlias))
 )
 ```
+
+Add single entry in the selected set:
+
+```php
+// DQL: SELECT e, u FROM ...
+Spec::addSelect(Spec::selectEntity($dqlAlias))
+```

--- a/docs/0-usage.md
+++ b/docs/0-usage.md
@@ -225,3 +225,30 @@ Add single entry in the selected set:
 // DQL: SELECT e, u FROM ...
 Spec::addSelect(Spec::selectEntity($dqlAlias))
 ```
+
+Use aliases for selection fields:
+
+```php
+// DQL: SELECT e.name AS author FROM ...
+Spec::select(Spec::selectAs(Spec::field('name'), 'author'))
+```
+
+Add single hidden field in the selected set:
+
+```php
+// DQL: SELECT e, u.name HIDDEN author FROM ...
+Spec::addSelect(Spec::selectHiddenAs(Spec::field('email', $dqlAlias), 'author')))
+```
+
+Use expression in selection for add product discount to the result:
+
+```php
+// DQL: SELECT (e.price_old is not null and e.price_current < e.price_old) discount FROM ...
+Spec::select(Spec::selectAs(
+    Spec::andX(
+        Spec::isNotNull('price_old'),
+        Spec::lt(Spec::field('price_current'), Spec::field('price_old'))
+    ),
+    'discount'
+))
+```

--- a/docs/0-usage.md
+++ b/docs/0-usage.md
@@ -236,14 +236,14 @@ Spec::select(Spec::selectAs(Spec::field('name'), 'author'))
 Add single hidden field in the selected set:
 
 ```php
-// DQL: SELECT e, u.name HIDDEN author FROM ...
+// DQL: SELECT e, u.name AS HIDDEN author FROM ...
 Spec::addSelect(Spec::selectHiddenAs(Spec::field('email', $dqlAlias), 'author')))
 ```
 
 Use expression in selection for add product discount to the result:
 
 ```php
-// DQL: SELECT (e.price_old is not null and e.price_current < e.price_old) discount FROM ...
+// DQL: SELECT (e.price_old is not null and e.price_current < e.price_old) AS discount FROM ...
 Spec::select(Spec::selectAs(
     Spec::andX(
         Spec::isNotNull('price_old'),
@@ -256,7 +256,7 @@ Spec::select(Spec::selectAs(
 Use aliases in conditions to search a cheap products:
 
 ```php
-// DQL: SELECT e.price_current price FROM ... WHERE price < :low_cost_limit
+// DQL: SELECT e.price_current AS price FROM ... WHERE price < :low_cost_limit
 Spec::andX(
     Spec::select(Spec::selectAs('price_current', 'price')),
     Spec::lt(Spec::alias('price'), $low_cost_limit)

--- a/src/Operand/Alias.php
+++ b/src/Operand/Alias.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Happyr\DoctrineSpecification\Operand;
+
+use Doctrine\ORM\QueryBuilder;
+
+class Alias implements Operand
+{
+    /**
+     * @var string
+     */
+    private $alias = '';
+
+    /**
+     * @param string $alias
+     */
+    public function __construct($alias)
+    {
+        $this->alias = $alias;
+    }
+
+    /**
+     * @param QueryBuilder $qb
+     * @param string       $dqlAlias
+     *
+     * @return string
+     */
+    public function transform(QueryBuilder $qb, $dqlAlias)
+    {
+        return $this->alias;
+    }
+}

--- a/src/Operand/Field.php
+++ b/src/Operand/Field.php
@@ -3,8 +3,9 @@
 namespace Happyr\DoctrineSpecification\Operand;
 
 use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Query\Selection\Selection;
 
-class Field implements Operand
+class Field implements Operand, Selection
 {
     /**
      * @var string

--- a/src/Query/AbstractSelect.php
+++ b/src/Query/AbstractSelect.php
@@ -33,14 +33,12 @@ abstract class AbstractSelect implements QueryModifier
             $selections[] = $selection->transform($qb, $dqlAlias);
         }
 
-        $type = $this->getSelectType();
-        $qb->$type($selections);
+        $this->modifySelection($qb, $selections);
     }
 
     /**
-     * Return a select type (ie a function of QueryBuilder) like: "select", "addSelect".
-     *
-     * @return string
+     * @param QueryBuilder $qb
+     * @param string[]     $selections
      */
-    abstract protected function getSelectType();
+    abstract protected function modifySelection(QueryBuilder $qb, array $selections);
 }

--- a/src/Query/AbstractSelect.php
+++ b/src/Query/AbstractSelect.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Happyr\DoctrineSpecification\Query;
+
+use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Query\Selection\ArgumentToSelectionConverter;
+use Happyr\DoctrineSpecification\Query\Selection\Selection;
+
+abstract class AbstractSelect implements QueryModifier
+{
+    /**
+     * @var Selection[]
+     */
+    private $selections;
+
+    /**
+     * @param mixed $field
+     */
+    public function __construct($field)
+    {
+        $this->selections = is_array($field) ? $field : func_get_args();
+    }
+
+    /**
+     * @param QueryBuilder $qb
+     * @param string       $dqlAlias
+     */
+    public function modify(QueryBuilder $qb, $dqlAlias)
+    {
+        $selections = [];
+        foreach ($this->selections as $selection) {
+            $selection = ArgumentToSelectionConverter::toSelection($selection);
+            $selections[] = $selection->transform($qb, $dqlAlias);
+        }
+
+        $type = $this->getSelectType();
+        $qb->$type($selections);
+    }
+
+    /**
+     * Return a select type (ie a function of QueryBuilder) like: "select", "addSelect".
+     *
+     * @return string
+     */
+    abstract protected function getSelectType();
+}

--- a/src/Query/AddSelect.php
+++ b/src/Query/AddSelect.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Happyr\DoctrineSpecification\Query;
+
+class AddSelect extends AbstractSelect
+{
+    /**
+     * @return string
+     */
+    protected function getSelectType()
+    {
+        return 'addSelect';
+    }
+}

--- a/src/Query/AddSelect.php
+++ b/src/Query/AddSelect.php
@@ -2,13 +2,16 @@
 
 namespace Happyr\DoctrineSpecification\Query;
 
+use Doctrine\ORM\QueryBuilder;
+
 class AddSelect extends AbstractSelect
 {
     /**
-     * @return string
+     * @param QueryBuilder $qb
+     * @param string[]     $selections
      */
-    protected function getSelectType()
+    protected function modifySelection(QueryBuilder $qb, array $selections)
     {
-        return 'addSelect';
+        $qb->addSelect($selections);
     }
 }

--- a/src/Query/Select.php
+++ b/src/Query/Select.php
@@ -2,13 +2,16 @@
 
 namespace Happyr\DoctrineSpecification\Query;
 
+use Doctrine\ORM\QueryBuilder;
+
 class Select extends AbstractSelect
 {
     /**
-     * @return string
+     * @param QueryBuilder $qb
+     * @param string[]     $selections
      */
-    protected function getSelectType()
+    protected function modifySelection(QueryBuilder $qb, array $selections)
     {
-        return 'select';
+        $qb->select($selections);
     }
 }

--- a/src/Query/Select.php
+++ b/src/Query/Select.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Happyr\DoctrineSpecification\Query;
+
+class Select extends AbstractSelect
+{
+    /**
+     * @return string
+     */
+    protected function getSelectType()
+    {
+        return 'select';
+    }
+}

--- a/src/Query/Selection/AbstractSelectAs.php
+++ b/src/Query/Selection/AbstractSelectAs.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Happyr\DoctrineSpecification\Query\Selection;
+
+use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Filter\Filter;
+use Happyr\DoctrineSpecification\Operand\ArgumentToOperandConverter;
+use Happyr\DoctrineSpecification\Operand\Operand;
+
+abstract class AbstractSelectAs implements Selection
+{
+    /**
+     * @var Operand|Filter|string
+     */
+    private $expression;
+
+    /**
+     * @var string
+     */
+    private $alias = '';
+
+    /**
+     * @param Filter|Operand|string $expression
+     * @param string                $alias
+     */
+    public function __construct($expression, $alias)
+    {
+        $this->expression = $expression;
+        $this->alias = $alias;
+    }
+
+    /**
+     * @param QueryBuilder $qb
+     * @param string       $dqlAlias
+     *
+     * @return string
+     */
+    public function transform(QueryBuilder $qb, $dqlAlias)
+    {
+        if ($this->expression instanceof Filter) {
+            $expression = $this->expression->getFilter($qb, $dqlAlias);
+        } else {
+            $expression = ArgumentToOperandConverter::toField($this->expression);
+            $expression = $expression->transform($qb, $dqlAlias);
+        }
+
+        return sprintf($this->getAliasFormat(), $expression, $this->alias);
+    }
+
+    /**
+     * Return a select format.
+     *
+     * @return string
+     */
+    abstract protected function getAliasFormat();
+}

--- a/src/Query/Selection/ArgumentToSelectionConverter.php
+++ b/src/Query/Selection/ArgumentToSelectionConverter.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Happyr\DoctrineSpecification\Query\Selection;
+
+use Happyr\DoctrineSpecification\Operand\Field;
+
+/**
+ * This service is intended for backward compatibility and may be removed in the future.
+ */
+class ArgumentToSelectionConverter
+{
+    /**
+     * Convert the argument into the field operand if it is not an selection.
+     *
+     * @param Selection|string $argument
+     *
+     * @return Selection
+     */
+    public static function toSelection($argument)
+    {
+        if ($argument instanceof Selection) {
+            return $argument;
+        }
+
+        return new Field($argument);
+    }
+}

--- a/src/Query/Selection/SelectAs.php
+++ b/src/Query/Selection/SelectAs.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Happyr\DoctrineSpecification\Query\Selection;
+
+class SelectAs extends AbstractSelectAs
+{
+    /**
+     * @return string
+     */
+    protected function getAliasFormat()
+    {
+        return '(%s) AS %s';
+    }
+}

--- a/src/Query/Selection/SelectEntity.php
+++ b/src/Query/Selection/SelectEntity.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Happyr\DoctrineSpecification\Query\Selection;
+
+use Doctrine\ORM\QueryBuilder;
+
+class SelectEntity implements Selection
+{
+    /**
+     * @var string
+     */
+    private $dqlAlias = '';
+
+    /**
+     * @param string $dqlAlias
+     */
+    public function __construct($dqlAlias)
+    {
+        $this->dqlAlias = $dqlAlias;
+    }
+
+    /**
+     * @param QueryBuilder $qb
+     * @param string       $dqlAlias
+     *
+     * @return string
+     */
+    public function transform(QueryBuilder $qb, $dqlAlias)
+    {
+        return $this->dqlAlias;
+    }
+}

--- a/src/Query/Selection/SelectHiddenAs.php
+++ b/src/Query/Selection/SelectHiddenAs.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Happyr\DoctrineSpecification\Query\Selection;
+
+class SelectHiddenAs extends AbstractSelectAs
+{
+    /**
+     * @return string
+     */
+    protected function getAliasFormat()
+    {
+        return '(%s) AS HIDDEN %s';
+    }
+}

--- a/src/Query/Selection/Selection.php
+++ b/src/Query/Selection/Selection.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Happyr\DoctrineSpecification\Query\Selection;
+
+use Doctrine\ORM\QueryBuilder;
+
+interface Selection
+{
+    /**
+     * @param QueryBuilder $qb
+     * @param string       $dqlAlias
+     *
+     * @return string
+     */
+    public function transform(QueryBuilder $qb, $dqlAlias);
+}

--- a/src/Spec.php
+++ b/src/Spec.php
@@ -27,7 +27,9 @@ use Happyr\DoctrineSpecification\Query\Offset;
 use Happyr\DoctrineSpecification\Query\OrderBy;
 use Happyr\DoctrineSpecification\Query\QueryModifier;
 use Happyr\DoctrineSpecification\Query\Select;
+use Happyr\DoctrineSpecification\Query\Selection\SelectAs;
 use Happyr\DoctrineSpecification\Query\Selection\SelectEntity;
+use Happyr\DoctrineSpecification\Query\Selection\SelectHiddenAs;
 use Happyr\DoctrineSpecification\Query\Slice;
 use Happyr\DoctrineSpecification\Result\AsArray;
 use Happyr\DoctrineSpecification\Result\AsSingleScalar;
@@ -203,6 +205,28 @@ class Spec
     public static function selectEntity($dqlAlias)
     {
         return new SelectEntity($dqlAlias);
+    }
+
+    /**
+     * @param Filter|Operand|string $expression
+     * @param string                $alias
+     *
+     * @return SelectAs
+     */
+    public static function selectAs($expression, $alias)
+    {
+        return new SelectAs($expression, $alias);
+    }
+
+    /**
+     * @param Filter|Operand|string $expression
+     * @param string                $alias
+     *
+     * @return SelectHiddenAs
+     */
+    public static function selectHiddenAs($expression, $alias)
+    {
+        return new SelectHiddenAs($expression, $alias);
     }
 
     /*

--- a/src/Spec.php
+++ b/src/Spec.php
@@ -27,6 +27,7 @@ use Happyr\DoctrineSpecification\Query\Offset;
 use Happyr\DoctrineSpecification\Query\OrderBy;
 use Happyr\DoctrineSpecification\Query\QueryModifier;
 use Happyr\DoctrineSpecification\Query\Select;
+use Happyr\DoctrineSpecification\Query\Selection\SelectEntity;
 use Happyr\DoctrineSpecification\Query\Slice;
 use Happyr\DoctrineSpecification\Result\AsArray;
 use Happyr\DoctrineSpecification\Result\AsSingleScalar;
@@ -192,6 +193,16 @@ class Spec
     public static function addSelect($field)
     {
         return new AddSelect(func_get_args());
+    }
+
+    /**
+     * @param string $dqlAlias
+     *
+     * @return SelectEntity
+     */
+    public static function selectEntity($dqlAlias)
+    {
+        return new SelectEntity($dqlAlias);
     }
 
     /*

--- a/src/Spec.php
+++ b/src/Spec.php
@@ -12,6 +12,7 @@ use Happyr\DoctrineSpecification\Filter\Like;
 use Happyr\DoctrineSpecification\Logic\AndX;
 use Happyr\DoctrineSpecification\Logic\Not;
 use Happyr\DoctrineSpecification\Logic\OrX;
+use Happyr\DoctrineSpecification\Operand\Alias;
 use Happyr\DoctrineSpecification\Operand\Field;
 use Happyr\DoctrineSpecification\Operand\LikePattern;
 use Happyr\DoctrineSpecification\Operand\Operand;
@@ -486,5 +487,15 @@ class Spec
     public static function likePattern($value, $format = LikePattern::CONTAINS)
     {
         return new LikePattern($value, $format);
+    }
+
+    /**
+     * @param string $alias
+     *
+     * @return Alias
+     */
+    public static function alias($alias)
+    {
+        return new Alias($alias);
     }
 }

--- a/src/Spec.php
+++ b/src/Spec.php
@@ -17,6 +17,7 @@ use Happyr\DoctrineSpecification\Operand\LikePattern;
 use Happyr\DoctrineSpecification\Operand\Operand;
 use Happyr\DoctrineSpecification\Operand\Value;
 use Happyr\DoctrineSpecification\Operand\Values;
+use Happyr\DoctrineSpecification\Query\AddSelect;
 use Happyr\DoctrineSpecification\Query\GroupBy;
 use Happyr\DoctrineSpecification\Query\InnerJoin;
 use Happyr\DoctrineSpecification\Query\Join;
@@ -25,6 +26,7 @@ use Happyr\DoctrineSpecification\Query\Limit;
 use Happyr\DoctrineSpecification\Query\Offset;
 use Happyr\DoctrineSpecification\Query\OrderBy;
 use Happyr\DoctrineSpecification\Query\QueryModifier;
+use Happyr\DoctrineSpecification\Query\Select;
 use Happyr\DoctrineSpecification\Query\Slice;
 use Happyr\DoctrineSpecification\Result\AsArray;
 use Happyr\DoctrineSpecification\Result\AsSingleScalar;
@@ -166,6 +168,30 @@ class Spec
     public static function groupBy($field, $dqlAlias = null)
     {
         return new GroupBy($field, $dqlAlias);
+    }
+
+    /*
+     * Selection
+     */
+
+    /**
+     * @param mixed $field
+     *
+     * @return Select
+     */
+    public static function select($field)
+    {
+        return new Select(func_get_args());
+    }
+
+    /**
+     * @param mixed $field
+     *
+     * @return AddSelect
+     */
+    public static function addSelect($field)
+    {
+        return new AddSelect(func_get_args());
     }
 
     /*

--- a/tests/Operand/AliasSpec.php
+++ b/tests/Operand/AliasSpec.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace tests\Happyr\DoctrineSpecification\Operand;
+
+use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Operand\Alias;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @mixin Alias
+ */
+class AliasSpec extends ObjectBehavior
+{
+    private $alias = 'foo';
+
+    public function let()
+    {
+        $this->beConstructedWith($this->alias);
+    }
+
+    public function it_is_a_alias()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Alias');
+    }
+
+    public function it_is_a_operand()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Operand');
+    }
+
+    public function it_is_transformable(QueryBuilder $qb)
+    {
+        $this->transform($qb, 'a')->shouldReturn($this->alias);
+    }
+}

--- a/tests/Query/AddSelectSpec.php
+++ b/tests/Query/AddSelectSpec.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace tests\Happyr\DoctrineSpecification\Query;
+
+use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Operand\Field;
+use Happyr\DoctrineSpecification\Query\AddSelect;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @mixin AddSelect
+ */
+class AddSelectSpec extends ObjectBehavior
+{
+    public function let()
+    {
+        $this->beConstructedWith('foo');
+    }
+
+    public function it_is_a_add_select()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Query\AddSelect');
+    }
+
+    public function it_is_a_specification()
+    {
+        $this->shouldHaveType('Happyr\DoctrineSpecification\Query\QueryModifier');
+    }
+
+    public function it_add_select_single_filed(QueryBuilder $qb)
+    {
+        $qb->addSelect(['a.foo'])->shouldBeCalled();
+        $this->modify($qb, 'a');
+    }
+
+    public function it_add_select_several_fields(QueryBuilder $qb)
+    {
+        $this->beConstructedWith('foo', 'bar');
+        $qb->addSelect(['b.foo', 'b.bar'])->shouldBeCalled();
+        $this->modify($qb, 'b');
+    }
+
+    public function it_add_select_several_fields_as_array(QueryBuilder $qb)
+    {
+        $this->beConstructedWith(['foo', 'bar']);
+        $qb->addSelect(['b.foo', 'b.bar'])->shouldBeCalled();
+        $this->modify($qb, 'b');
+    }
+
+    public function it_add_select_operand(QueryBuilder $qb)
+    {
+        $this->beConstructedWith('foo', new Field('bar'));
+        $qb->addSelect(['b.foo', 'b.bar'])->shouldBeCalled();
+        $this->modify($qb, 'b');
+    }
+}

--- a/tests/Query/SelectSpec.php
+++ b/tests/Query/SelectSpec.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace tests\Happyr\DoctrineSpecification\Query;
+
+use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Operand\Field;
+use Happyr\DoctrineSpecification\Query\Select;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @mixin Select
+ */
+class SelectSpec extends ObjectBehavior
+{
+    public function let()
+    {
+        $this->beConstructedWith('foo');
+    }
+
+    public function it_is_a_select()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Query\Select');
+    }
+
+    public function it_is_a_specification()
+    {
+        $this->shouldHaveType('Happyr\DoctrineSpecification\Query\QueryModifier');
+    }
+
+    public function it_select_single_filed(QueryBuilder $qb)
+    {
+        $qb->select(['a.foo'])->shouldBeCalled();
+        $this->modify($qb, 'a');
+    }
+
+    public function it_select_several_fields(QueryBuilder $qb)
+    {
+        $this->beConstructedWith('foo', 'bar');
+        $qb->select(['b.foo', 'b.bar'])->shouldBeCalled();
+        $this->modify($qb, 'b');
+    }
+
+    public function it_select_several_fields_as_array(QueryBuilder $qb)
+    {
+        $this->beConstructedWith(['foo', 'bar']);
+        $qb->select(['b.foo', 'b.bar'])->shouldBeCalled();
+        $this->modify($qb, 'b');
+    }
+
+    public function it_select_operand(QueryBuilder $qb)
+    {
+        $this->beConstructedWith('foo', new Field('bar'));
+        $qb->select(['b.foo', 'b.bar'])->shouldBeCalled();
+        $this->modify($qb, 'b');
+    }
+}

--- a/tests/Query/Selection/ArgumentToSelectionConverterSpec.php
+++ b/tests/Query/Selection/ArgumentToSelectionConverterSpec.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace tests\Happyr\DoctrineSpecification\Query\Selection;
+
+use Happyr\DoctrineSpecification\Operand\Field;
+use Happyr\DoctrineSpecification\Query\Selection\ArgumentToSelectionConverter;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @mixin ArgumentToSelectionConverter
+ */
+class ArgumentToSelectionConverterSpec extends ObjectBehavior
+{
+    public function it_is_a_converter()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Query\Selection\ArgumentToSelectionConverter');
+    }
+
+    public function it_not_convert_field_to_selection(Field $field)
+    {
+        $this->toSelection($field)->shouldReturn($field);
+    }
+
+    public function it_convert_argument_to_field()
+    {
+        $this->toSelection('foo')->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Field');
+    }
+}

--- a/tests/Query/Selection/SelectAsSpec.php
+++ b/tests/Query/Selection/SelectAsSpec.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace tests\Happyr\DoctrineSpecification\Query\Selection;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Filter\Equals;
+use Happyr\DoctrineSpecification\Operand\Field;
+use Happyr\DoctrineSpecification\Operand\Value;
+use Happyr\DoctrineSpecification\Query\Selection\SelectAs;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @mixin SelectAs
+ */
+class SelectAsSpec extends ObjectBehavior
+{
+    private $field = 'foo';
+
+    private $alias = 'bar';
+
+    public function let()
+    {
+        $this->beConstructedWith($this->field, $this->alias);
+    }
+
+    public function it_is_a_select_as()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Query\Selection\SelectAs');
+    }
+
+    public function it_is_a_selection()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Query\Selection\Selection');
+    }
+
+    public function it_is_transformable(QueryBuilder $qb)
+    {
+        $dqlAlias = 'a';
+        $expression = '(a.foo) AS bar';
+
+        $this->transform($qb, $dqlAlias)->shouldReturn($expression);
+    }
+
+    public function it_is_transformable_field(QueryBuilder $qb)
+    {
+        $dqlAlias = 'a';
+        $expression = '(a.foo) AS bar';
+        $field = new Field('foo');
+
+        $this->beConstructedWith($field, $this->alias);
+        $this->transform($qb, $dqlAlias)->shouldReturn($expression);
+    }
+
+    public function it_is_transformable_value(QueryBuilder $qb, ArrayCollection $parameters)
+    {
+        $dqlAlias = 'a';
+        $expression = '(:comparison_10) AS bar';
+        $value = new Value('foo');
+
+        $this->beConstructedWith($value, $this->alias);
+
+
+        $qb->getParameters()->willReturn($parameters);
+        $parameters->count()->willReturn(10);
+
+        $qb->setParameter('comparison_10', 'foo', null)->shouldBeCalled();
+
+        $this->transform($qb, $dqlAlias)->shouldReturn($expression);
+    }
+
+    public function it_is_transformable_filter(QueryBuilder $qb, ArrayCollection $parameters)
+    {
+        $dqlAlias = 'a';
+        $expression = '(a.foo = :comparison_10) AS bar';
+        $filter = new Equals('foo', 'bar');
+
+        $this->beConstructedWith($filter, $this->alias);
+
+        $qb->getParameters()->willReturn($parameters);
+        $parameters->count()->willReturn(10);
+
+        $qb->setParameter('comparison_10', 'bar', null)->shouldBeCalled();
+
+        $this->transform($qb, $dqlAlias)->shouldReturn($expression);
+    }
+}

--- a/tests/Query/Selection/SelectAsSpec.php
+++ b/tests/Query/Selection/SelectAsSpec.php
@@ -60,7 +60,6 @@ class SelectAsSpec extends ObjectBehavior
 
         $this->beConstructedWith($value, $this->alias);
 
-
         $qb->getParameters()->willReturn($parameters);
         $parameters->count()->willReturn(10);
 

--- a/tests/Query/Selection/SelectEntitySpec.php
+++ b/tests/Query/Selection/SelectEntitySpec.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace tests\Happyr\DoctrineSpecification\Query\Selection;
+
+use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Query\Selection\SelectEntity;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @mixin SelectEntity
+ */
+class SelectEntitySpec extends ObjectBehavior
+{
+    private $dqlAlias = 'u';
+
+    public function let()
+    {
+        $this->beConstructedWith($this->dqlAlias);
+    }
+
+    public function it_is_a_select_entity()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Query\Selection\SelectEntity');
+    }
+
+    public function it_is_a_selection()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Query\Selection\Selection');
+    }
+
+    public function it_is_transformable(QueryBuilder $qb)
+    {
+        $this->transform($qb, 'a')->shouldReturn($this->dqlAlias);
+    }
+}

--- a/tests/Query/Selection/SelectHiddenAsSpec.php
+++ b/tests/Query/Selection/SelectHiddenAsSpec.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace tests\Happyr\DoctrineSpecification\Query\Selection;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Filter\Equals;
+use Happyr\DoctrineSpecification\Operand\Field;
+use Happyr\DoctrineSpecification\Operand\Value;
+use Happyr\DoctrineSpecification\Query\Selection\SelectHiddenAs;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @mixin SelectHiddenAs
+ */
+class SelectHiddenAsSpec extends ObjectBehavior
+{
+    private $field = 'foo';
+
+    private $alias = 'bar';
+
+    public function let()
+    {
+        $this->beConstructedWith($this->field, $this->alias);
+    }
+
+    public function it_is_a_select_as()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Query\Selection\SelectHiddenAs');
+    }
+
+    public function it_is_a_selection()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Query\Selection\Selection');
+    }
+
+    public function it_is_transformable(QueryBuilder $qb)
+    {
+        $dqlAlias = 'a';
+        $expression = '(a.foo) AS HIDDEN bar';
+
+        $this->transform($qb, $dqlAlias)->shouldReturn($expression);
+    }
+
+    public function it_is_transformable_field(QueryBuilder $qb)
+    {
+        $dqlAlias = 'a';
+        $expression = '(a.foo) AS HIDDEN bar';
+        $field = new Field('foo');
+
+        $this->beConstructedWith($field, $this->alias);
+        $this->transform($qb, $dqlAlias)->shouldReturn($expression);
+    }
+
+    public function it_is_transformable_value(QueryBuilder $qb, ArrayCollection $parameters)
+    {
+        $dqlAlias = 'a';
+        $expression = '(:comparison_10) AS HIDDEN bar';
+        $value = new Value('foo');
+
+        $this->beConstructedWith($value, $this->alias);
+
+
+        $qb->getParameters()->willReturn($parameters);
+        $parameters->count()->willReturn(10);
+
+        $qb->setParameter('comparison_10', 'foo', null)->shouldBeCalled();
+
+        $this->transform($qb, $dqlAlias)->shouldReturn($expression);
+    }
+
+    public function it_is_transformable_filter(QueryBuilder $qb, ArrayCollection $parameters)
+    {
+        $dqlAlias = 'a';
+        $expression = '(a.foo = :comparison_10) AS HIDDEN bar';
+        $filter = new Equals('foo', 'bar');
+
+        $this->beConstructedWith($filter, $this->alias);
+
+        $qb->getParameters()->willReturn($parameters);
+        $parameters->count()->willReturn(10);
+
+        $qb->setParameter('comparison_10', 'bar', null)->shouldBeCalled();
+
+        $this->transform($qb, $dqlAlias)->shouldReturn($expression);
+    }
+}

--- a/tests/Query/Selection/SelectHiddenAsSpec.php
+++ b/tests/Query/Selection/SelectHiddenAsSpec.php
@@ -60,7 +60,6 @@ class SelectHiddenAsSpec extends ObjectBehavior
 
         $this->beConstructedWith($value, $this->alias);
 
-
         $qb->getParameters()->willReturn($parameters);
         $parameters->count()->willReturn(10);
 

--- a/tests/SpecSpec.php
+++ b/tests/SpecSpec.php
@@ -29,4 +29,14 @@ class SpecSpec extends ObjectBehavior
     {
         $this->selectEntity('u')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Query\Selection\SelectEntity');
     }
+
+    public function it_creates_select_as_selection()
+    {
+        $this->selectAs('foo', 'bar')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Query\Selection\SelectAs');
+    }
+
+    public function it_creates_select_hidden_as_selection()
+    {
+        $this->selectHiddenAs('foo', 'bar')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Query\Selection\SelectHiddenAs');
+    }
 }

--- a/tests/SpecSpec.php
+++ b/tests/SpecSpec.php
@@ -14,4 +14,14 @@ class SpecSpec extends ObjectBehavior
     {
         $this->andX()->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Logic\LogicX');
     }
+
+    public function it_creates_select_query_modifier()
+    {
+        $this->select('foo')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Query\Select');
+    }
+
+    public function it_creates_add_select_query_modifier()
+    {
+        $this->addSelect('foo')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Query\AddSelect');
+    }
 }

--- a/tests/SpecSpec.php
+++ b/tests/SpecSpec.php
@@ -39,4 +39,9 @@ class SpecSpec extends ObjectBehavior
     {
         $this->selectHiddenAs('foo', 'bar')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Query\Selection\SelectHiddenAs');
     }
+
+    public function it_creates_alias_operand()
+    {
+        $this->alias('foo')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Operand\Alias');
+    }
 }

--- a/tests/SpecSpec.php
+++ b/tests/SpecSpec.php
@@ -24,4 +24,9 @@ class SpecSpec extends ObjectBehavior
     {
         $this->addSelect('foo')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Query\AddSelect');
     }
+
+    public function it_creates_select_entity_selection()
+    {
+        $this->selectEntity('u')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Query\Selection\SelectEntity');
+    }
 }


### PR DESCRIPTION
This is a implementation of the selection control from #169 feature.

Selection single field:

```php
// DQL: SELECT e.email FROM ...
Spec::select('email')
// or
Spec::select(Spec::field('email'))
```

Add single field in the selected set:

```php
// DQL: SELECT e, u.email FROM ...
Spec::addSelect(Spec::field('email', $dqlAlias))
```

Add one more custom fields in the selected set:

```php
// DQL: SELECT e.title, e.cover, u.name, u.avatar FROM ...
Spec::andX(
    Spec::select('title', 'cover'),
    Spec::addSelect(Spec::field('name', $dqlAlias), Spec::field('avatar', $dqlAlias))
)
```

Add single entry in the selected set:

```php
// DQL: SELECT e, u FROM ...
Spec::addSelect(Spec::selectEntity($dqlAlias))
```

Use aliases for selection fields:

```php
// DQL: SELECT e.name AS author FROM ...
Spec::select(Spec::selectAs(Spec::field('name'), 'author'))
```

Add single hidden field in the selected set:

```php
// DQL: SELECT e, u.name AS HIDDEN author FROM ...
Spec::addSelect(Spec::selectHiddenAs(Spec::field('email', $dqlAlias), 'author')))
```

Use expression in selection for add product discount to the result:

```php
// DQL: SELECT (e.price_old is not null and e.price_current < e.price_old) AS discount FROM ...
Spec::select(Spec::selectAs(
    Spec::andX(
        Spec::isNotNull('price_old'),
        Spec::lt(Spec::field('price_current'), Spec::field('price_old'))
    ),
    'discount'
))
```

Use aliases in conditions to search a cheap products:

```php
// DQL: SELECT e.price_current AS price FROM ... WHERE price < :low_cost_limit
Spec::andX(
    Spec::select(Spec::selectAs('price_current', 'price')),
    Spec::lt(Spec::alias('price'), $low_cost_limit)
)
```