### PR TITLE
Implementation of Bitwise operands

### DIFF
--- a/docs/0-usage.md
+++ b/docs/0-usage.md
@@ -189,3 +189,27 @@ $spec = Spec::gt('day', Spec::value($day, Type::DATE));
 // DQL: e.day IN (:days)
 $spec = Spec::in('day', Spec::values($days, Type::DATE));
 ```
+
+# Bitwise operands
+
+You can use bitwise operations in specifications such as `&`, `|`, `^`, `<<`, `>>`, `~`.
+
+For example, check the access for reading something with a bit mask:
+
+```php
+// DQL: (u.access & 0100) = 0100
+$spec = Spec::eq(Spec::bAnd('access', UserAccess::READ), UserAccess::READ);
+```
+
+You can put bitwise operations in each other. For example, select not readed mails:
+
+```php
+// DQL: (m.status & (~ 0100)) = 0100
+$spec = Spec::eq(
+    Spec::bAnd(
+        Spec::field('status'),
+        Spec::bNot(Spec::value(MailStatus::READED))
+    ),
+    Spec::value(MailStatus::READED)
+);
+```

--- a/docs/0-usage.md
+++ b/docs/0-usage.md
@@ -204,12 +204,12 @@ $spec = Spec::eq(Spec::bAnd('access', UserAccess::READ), UserAccess::READ);
 You can put bitwise operations in each other. For example, select not readed mails:
 
 ```php
-// DQL: (m.status & (~ 0100)) = 0100
+// DQL: (m.status & (~ 0100)) = m.status
 $spec = Spec::eq(
     Spec::bAnd(
         Spec::field('status'),
         Spec::bNot(Spec::value(MailStatus::READED))
     ),
-    Spec::value(MailStatus::READED)
+    Spec::field('status')
 );
 ```

--- a/src/Operand/BitAnd.php
+++ b/src/Operand/BitAnd.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Happyr\DoctrineSpecification\Operand;
+
+class BitAnd extends Bitwise
+{
+    /**
+     * @param Operand|string $field
+     * @param Operand|string $value
+     */
+    public function __construct($field, $value)
+    {
+        parent::__construct(self::B_AND, $field, $value);
+    }
+}

--- a/src/Operand/BitLeftShift.php
+++ b/src/Operand/BitLeftShift.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Happyr\DoctrineSpecification\Operand;
+
+class BitLeftShift extends Bitwise
+{
+    /**
+     * @param Operand|string $field
+     * @param Operand|string $value
+     */
+    public function __construct($field, $value)
+    {
+        parent::__construct(self::B_LS, $field, $value);
+    }
+}

--- a/src/Operand/BitNot.php
+++ b/src/Operand/BitNot.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Happyr\DoctrineSpecification\Operand;
+
+use Doctrine\ORM\QueryBuilder;
+
+class BitNot implements Operand
+{
+    /**
+     * @var Operand|string
+     */
+    private $field;
+
+    /**
+     * @param Operand|string $field
+     */
+    public function __construct($field)
+    {
+        $this->field = $field;
+    }
+
+    /**
+     * @param QueryBuilder $qb
+     * @param string       $dqlAlias
+     *
+     * @return string
+     */
+    public function transform(QueryBuilder $qb, $dqlAlias)
+    {
+        $field = ArgumentToOperandConverter::toField($this->field);
+
+        $field = $field->transform($qb, $dqlAlias);
+
+        return sprintf('(~ %s)', $field);
+    }
+}

--- a/src/Operand/BitOr.php
+++ b/src/Operand/BitOr.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Happyr\DoctrineSpecification\Operand;
+
+class BitOr extends Bitwise
+{
+    /**
+     * @param Operand|string $field
+     * @param Operand|string $value
+     */
+    public function __construct($field, $value)
+    {
+        parent::__construct(self::B_OR, $field, $value);
+    }
+}

--- a/src/Operand/BitRightShift.php
+++ b/src/Operand/BitRightShift.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Happyr\DoctrineSpecification\Operand;
+
+class BitRightShift extends Bitwise
+{
+    /**
+     * @param Operand|string $field
+     * @param Operand|string $value
+     */
+    public function __construct($field, $value)
+    {
+        parent::__construct(self::B_RS, $field, $value);
+    }
+}

--- a/src/Operand/BitXor.php
+++ b/src/Operand/BitXor.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Happyr\DoctrineSpecification\Operand;
+
+class BitXor extends Bitwise
+{
+    /**
+     * @param Operand|string $field
+     * @param Operand|string $value
+     */
+    public function __construct($field, $value)
+    {
+        parent::__construct(self::B_XOR, $field, $value);
+    }
+}

--- a/src/Operand/Bitwise.php
+++ b/src/Operand/Bitwise.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Happyr\DoctrineSpecification\Operand;
+
+use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Exception\InvalidArgumentException;
+
+abstract class Bitwise implements Operand
+{
+    const B_AND = '&';
+
+    const B_OR = '|';
+
+    const B_XOR = '^';
+
+    const B_LS = '<<';
+
+    const B_RS = '>>';
+
+    /**
+     * @var string[]
+     */
+    private static $operations = array(
+        self::B_AND,
+        self::B_OR,
+        self::B_XOR,
+        self::B_LS,
+        self::B_RS,
+    );
+
+    /**
+     * @var string
+     */
+    private $operation = '';
+
+    /**
+     * @var Operand|string
+     */
+    private $field;
+
+    /**
+     * @var Operand|string
+     */
+    private $value;
+
+    /**
+     * @param string         $operation
+     * @param Operand|string $field
+     * @param Operand|string $value
+     */
+    public function __construct($operation, $field, $value)
+    {
+        if (!in_array($operation, self::$operations)) {
+            throw new InvalidArgumentException(sprintf(
+                '"%s" is not a valid bitwise operation. Valid operations are: "%s"',
+                $operation,
+                implode(', ', self::$operations)
+            ));
+        }
+
+        $this->operation = $operation;
+        $this->field = $field;
+        $this->value = $value;
+    }
+
+    /**
+     * @param QueryBuilder $qb
+     * @param string       $dqlAlias
+     *
+     * @return string
+     */
+    public function transform(QueryBuilder $qb, $dqlAlias)
+    {
+        $field = ArgumentToOperandConverter::toField($this->field);
+        $value = ArgumentToOperandConverter::toValue($this->value);
+
+        $field = $field->transform($qb, $dqlAlias);
+        $value = $value->transform($qb, $dqlAlias);
+
+        return sprintf('(%s %s %s)', $field, $this->operation, $value);
+    }
+}

--- a/src/Spec.php
+++ b/src/Spec.php
@@ -12,6 +12,12 @@ use Happyr\DoctrineSpecification\Filter\Like;
 use Happyr\DoctrineSpecification\Logic\AndX;
 use Happyr\DoctrineSpecification\Logic\Not;
 use Happyr\DoctrineSpecification\Logic\OrX;
+use Happyr\DoctrineSpecification\Operand\BitAnd;
+use Happyr\DoctrineSpecification\Operand\BitLeftShift;
+use Happyr\DoctrineSpecification\Operand\BitNot;
+use Happyr\DoctrineSpecification\Operand\BitOr;
+use Happyr\DoctrineSpecification\Operand\BitRightShift;
+use Happyr\DoctrineSpecification\Operand\BitXor;
 use Happyr\DoctrineSpecification\Operand\Field;
 use Happyr\DoctrineSpecification\Operand\LikePattern;
 use Happyr\DoctrineSpecification\Operand\Operand;
@@ -425,5 +431,74 @@ class Spec
     public static function likePattern($value, $format = LikePattern::CONTAINS)
     {
         return new LikePattern($value, $format);
+    }
+
+    /*
+     * Bitwise operands
+     */
+
+    /**
+     * @param Operand|string $field
+     * @param Operand|mixed  $value
+     *
+     * @return BitAnd
+     */
+    public static function bAnd($field, $value)
+    {
+        return new BitAnd($field, $value);
+    }
+
+    /**
+     * @param Operand|string $field
+     * @param Operand|mixed  $value
+     *
+     * @return BitOr
+     */
+    public static function bOr($field, $value)
+    {
+        return new BitOr($field, $value);
+    }
+
+    /**
+     * @param Operand|string $field
+     * @param Operand|mixed  $value
+     *
+     * @return BitXor
+     */
+    public static function bXor($field, $value)
+    {
+        return new BitXor($field, $value);
+    }
+
+    /**
+     * @param Operand|string $field
+     * @param Operand|mixed  $value
+     *
+     * @return BitLeftShift
+     */
+    public static function bLs($field, $value)
+    {
+        return new BitLeftShift($field, $value);
+    }
+
+    /**
+     * @param Operand|string $field
+     * @param Operand|mixed  $value
+     *
+     * @return BitRightShift
+     */
+    public static function bRs($field, $value)
+    {
+        return new BitRightShift($field, $value);
+    }
+
+    /**
+     * @param Operand|string $field
+     *
+     * @return BitNot
+     */
+    public static function bNot($field)
+    {
+        return new BitNot($field);
     }
 }

--- a/src/Spec.php
+++ b/src/Spec.php
@@ -644,6 +644,7 @@ class Spec
     {
         return new BitLeftShift($field, $value);
     }
+
     /**
      * @param Operand|string $field
      * @param Operand|mixed  $value

--- a/tests/Operand/BitAndSpec.php
+++ b/tests/Operand/BitAndSpec.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace tests\Happyr\DoctrineSpecification\Operand;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Operand\BitAnd;
+use Happyr\DoctrineSpecification\Operand\Field;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @mixin BitAnd
+ */
+class BitAndSpec extends ObjectBehavior
+{
+    private $field = 'foo';
+
+    private $value = 'bar';
+
+    public function let()
+    {
+        $this->beConstructedWith($this->field, $this->value);
+    }
+
+    public function it_is_a_bit_and()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\BitAnd');
+    }
+
+    public function it_is_a_operand()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Operand');
+    }
+
+    public function it_is_transformable(QueryBuilder $qb, ArrayCollection $parameters)
+    {
+        $qb->getParameters()->willReturn($parameters);
+        $parameters->count()->willReturn(10);
+
+        $qb->setParameter('comparison_10', $this->value, null)->shouldBeCalled();
+
+        $this->transform($qb, 'a')->shouldReturn('(a.foo & :comparison_10)');
+    }
+
+    public function it_is_transformable_add_fields(QueryBuilder $qb)
+    {
+        $this->beConstructedWith(new Field('foo'), new Field('bar'));
+        $this->transform($qb, 'a')->shouldReturn('(a.foo & a.bar)');
+    }
+}

--- a/tests/Operand/BitLeftShiftSpec.php
+++ b/tests/Operand/BitLeftShiftSpec.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace tests\Happyr\DoctrineSpecification\Operand;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Operand\BitLeftShift;
+use Happyr\DoctrineSpecification\Operand\Field;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @mixin BitLeftShift
+ */
+class BitLeftShiftSpec extends ObjectBehavior
+{
+    private $field = 'foo';
+
+    private $value = 'bar';
+
+    public function let()
+    {
+        $this->beConstructedWith($this->field, $this->value);
+    }
+
+    public function it_is_a_bit_left_shift()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\BitLeftShift');
+    }
+
+    public function it_is_a_operand()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Operand');
+    }
+
+    public function it_is_transformable(QueryBuilder $qb, ArrayCollection $parameters)
+    {
+        $qb->getParameters()->willReturn($parameters);
+        $parameters->count()->willReturn(10);
+
+        $qb->setParameter('comparison_10', $this->value, null)->shouldBeCalled();
+
+        $this->transform($qb, 'a')->shouldReturn('(a.foo << :comparison_10)');
+    }
+
+    public function it_is_transformable_add_fields(QueryBuilder $qb)
+    {
+        $this->beConstructedWith(new Field('foo'), new Field('bar'));
+        $this->transform($qb, 'a')->shouldReturn('(a.foo << a.bar)');
+    }
+}

--- a/tests/Operand/BitNotSpec.php
+++ b/tests/Operand/BitNotSpec.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace tests\Happyr\DoctrineSpecification\Operand;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Operand\BitNot;
+use Happyr\DoctrineSpecification\Operand\Field;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @mixin BitNot
+ */
+class BitNotSpec extends ObjectBehavior
+{
+    private $field = 'foo';
+
+    public function let()
+    {
+        $this->beConstructedWith($this->field);
+    }
+
+    public function it_is_a_bit_not()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\BitNot');
+    }
+
+    public function it_is_a_operand()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Operand');
+    }
+
+    public function it_is_transformable(QueryBuilder $qb)
+    {
+        $this->transform($qb, 'a')->shouldReturn('(~ a.foo)');
+    }
+}

--- a/tests/Operand/BitNotSpec.php
+++ b/tests/Operand/BitNotSpec.php
@@ -2,10 +2,8 @@
 
 namespace tests\Happyr\DoctrineSpecification\Operand;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Operand\BitNot;
-use Happyr\DoctrineSpecification\Operand\Field;
 use PhpSpec\ObjectBehavior;
 
 /**

--- a/tests/Operand/BitOrSpec.php
+++ b/tests/Operand/BitOrSpec.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace tests\Happyr\DoctrineSpecification\Operand;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Operand\BitOr;
+use Happyr\DoctrineSpecification\Operand\Field;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @mixin BitOr
+ */
+class BitOrSpec extends ObjectBehavior
+{
+    private $field = 'foo';
+
+    private $value = 'bar';
+
+    public function let()
+    {
+        $this->beConstructedWith($this->field, $this->value);
+    }
+
+    public function it_is_a_bit_or()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\BitOr');
+    }
+
+    public function it_is_a_operand()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Operand');
+    }
+
+    public function it_is_transformable(QueryBuilder $qb, ArrayCollection $parameters)
+    {
+        $qb->getParameters()->willReturn($parameters);
+        $parameters->count()->willReturn(10);
+
+        $qb->setParameter('comparison_10', $this->value, null)->shouldBeCalled();
+
+        $this->transform($qb, 'a')->shouldReturn('(a.foo | :comparison_10)');
+    }
+
+    public function it_is_transformable_add_fields(QueryBuilder $qb)
+    {
+        $this->beConstructedWith(new Field('foo'), new Field('bar'));
+        $this->transform($qb, 'a')->shouldReturn('(a.foo | a.bar)');
+    }
+}

--- a/tests/Operand/BitRightShiftSpec.php
+++ b/tests/Operand/BitRightShiftSpec.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace tests\Happyr\DoctrineSpecification\Operand;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Operand\BitRightShift;
+use Happyr\DoctrineSpecification\Operand\Field;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @mixin BitRightShift
+ */
+class BitRightShiftSpec extends ObjectBehavior
+{
+    private $field = 'foo';
+
+    private $value = 'bar';
+
+    public function let()
+    {
+        $this->beConstructedWith($this->field, $this->value);
+    }
+
+    public function it_is_a_bit_right_shift()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\BitRightShift');
+    }
+
+    public function it_is_a_operand()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Operand');
+    }
+
+    public function it_is_transformable(QueryBuilder $qb, ArrayCollection $parameters)
+    {
+        $qb->getParameters()->willReturn($parameters);
+        $parameters->count()->willReturn(10);
+
+        $qb->setParameter('comparison_10', $this->value, null)->shouldBeCalled();
+
+        $this->transform($qb, 'a')->shouldReturn('(a.foo >> :comparison_10)');
+    }
+
+    public function it_is_transformable_add_fields(QueryBuilder $qb)
+    {
+        $this->beConstructedWith(new Field('foo'), new Field('bar'));
+        $this->transform($qb, 'a')->shouldReturn('(a.foo >> a.bar)');
+    }
+}

--- a/tests/Operand/BitXorSpec.php
+++ b/tests/Operand/BitXorSpec.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace tests\Happyr\DoctrineSpecification\Operand;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Operand\BitXor;
+use Happyr\DoctrineSpecification\Operand\Field;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @mixin BitXor
+ */
+class BitXorSpec extends ObjectBehavior
+{
+    private $field = 'foo';
+
+    private $value = 'bar';
+
+    public function let()
+    {
+        $this->beConstructedWith($this->field, $this->value);
+    }
+
+    public function it_is_a_bit_xor()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\BitXor');
+    }
+
+    public function it_is_a_operand()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Operand');
+    }
+
+    public function it_is_transformable(QueryBuilder $qb, ArrayCollection $parameters)
+    {
+        $qb->getParameters()->willReturn($parameters);
+        $parameters->count()->willReturn(10);
+
+        $qb->setParameter('comparison_10', $this->value, null)->shouldBeCalled();
+
+        $this->transform($qb, 'a')->shouldReturn('(a.foo ^ :comparison_10)');
+    }
+
+    public function it_is_transformable_add_fields(QueryBuilder $qb)
+    {
+        $this->beConstructedWith(new Field('foo'), new Field('bar'));
+        $this->transform($qb, 'a')->shouldReturn('(a.foo ^ a.bar)');
+    }
+}

--- a/tests/SpecSpec.php
+++ b/tests/SpecSpec.php
@@ -14,4 +14,34 @@ class SpecSpec extends ObjectBehavior
     {
         $this->andX()->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Logic\LogicX');
     }
+
+    public function it_create_bit_and_operand()
+    {
+        $this->bAnd('foo', 'bar')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Operand\BitAnd');
+    }
+
+    public function it_create_bit_or_operand()
+    {
+        $this->bOr('foo', 'bar')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Operand\BitOr');
+    }
+
+    public function it_create_bit_xor_operand()
+    {
+        $this->bXor('foo', 'bar')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Operand\BitXor');
+    }
+
+    public function it_create_bit_left_shift_operand()
+    {
+        $this->bLs('foo', 'bar')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Operand\BitLeftShift');
+    }
+
+    public function it_create_bit_right_shift_operand()
+    {
+        $this->bRs('foo', 'bar')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Operand\BitRightShift');
+    }
+
+    public function it_create_bit_not_operand()
+    {
+        $this->bNot('foo')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Operand\BitNot');
+    }
 }


### PR DESCRIPTION
This is a implementation of the Bitwise operands from #169 feature.

You can use bitwise operations in specifications such as `&`, `|`, `^`, `<<`, `>>`, `~`.

For example, check the access for reading something with a bit mask:

```php
// DQL: (u.access & 0100) = 0100
$spec = Spec::eq(Spec::bAnd('access', UserAccess::READ), UserAccess::READ);
```

You can put bitwise operations in each other. For example, select not readed mails:

```php
// DQL: (m.status & (~ 0100)) = m.status
$spec = Spec::eq(
    Spec::bAnd(
        Spec::field('status'),
        Spec::bNot(Spec::value(MailStatus::READED))
    ),
    Spec::field('status')
);
```