### PR TITLE
 Implementation of Function operand

### DIFF
--- a/docs/0-usage.md
+++ b/docs/0-usage.md
@@ -189,3 +189,26 @@ $spec = Spec::gt('day', Spec::value($day, Type::DATE));
 // DQL: e.day IN (:days)
 $spec = Spec::in('day', Spec::values($days, Type::DATE));
 ```
+
+Use functions:
+
+```php
+// DQL: SIZE(e.products) > 2
+Spec::gt(Spec::SIZE('products'), 2);
+// or
+Spec::gt(Spec::fun('SIZE', 'products'), 2);
+// or
+Spec::gt(Spec::fun('SIZE', Spec::field('products')), 2);
+```
+
+Nested functions:
+
+```php
+// DQL: TRIM(LOWER(e.email)) = :email
+Spec::eq(Spec::TRIM(Spec::LOWER('email')), trim(strtolower($email)));
+// or
+Spec::eq(
+    Spec::fun('TRIM', Spec::fun('LOWER', Spec::field('email'))),
+    trim(strtolower($email))
+);
+```

--- a/src/Operand/PlatformFunction.php
+++ b/src/Operand/PlatformFunction.php
@@ -8,27 +8,42 @@ use Happyr\DoctrineSpecification\Exception\InvalidArgumentException;
 class PlatformFunction implements Operand
 {
     /**
+     * Doctrine internal functions.
+     *
+     * @see \Doctrine\ORM\Query\Parser
+     *
      * @var string[]
      */
     private static $doctrineFunctions = [
-        'IDENTITY',
-        'ABS',
-        'CONCAT',
-        'CURRENT_DATE',
-        'CURRENT_TIME',
-        'CURRENT_TIMESTAMP',
-        'LENGTH',
-        'LOCATE',
-        'LOWER',
-        'MOD',
-        'SIZE',
-        'SQRT',
-        'SUBSTRING',
-        'TRIM',
-        'UPPER',
-        'DATE_ADD',
-        'DATE_SUB',
-        'DATE_DIFF',
+        // String functions
+        'concat',
+        'substring',
+        'trim',
+        'lower',
+        'upper',
+        'identity',
+        // Numeric functions
+        'length',
+        'locate',
+        'abs',
+        'sqrt',
+        'mod',
+        'size',
+        'date_diff',
+        'bit_and',
+        'bit_or',
+        // Aggregate functions
+        'min',
+        'max',
+        'avg',
+        'sum',
+        'count',
+        // Datetime functions
+        'current_date',
+        'current_time',
+        'current_timestamp',
+        'date_add',
+        'date_sub',
     ];
 
     /**
@@ -65,7 +80,7 @@ class PlatformFunction implements Operand
      */
     public function transform(QueryBuilder $qb, $dqlAlias)
     {
-        if (!in_array(strtoupper($this->functionName), self::$doctrineFunctions) &&
+        if (!in_array(strtolower($this->functionName), self::$doctrineFunctions) &&
             !$qb->getEntityManager()->getConfiguration()->getCustomStringFunction($this->functionName) &&
             !$qb->getEntityManager()->getConfiguration()->getCustomNumericFunction($this->functionName) &&
             !$qb->getEntityManager()->getConfiguration()->getCustomDatetimeFunction($this->functionName)

--- a/src/Operand/PlatformFunction.php
+++ b/src/Operand/PlatformFunction.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Happyr\DoctrineSpecification\Operand;
+
+use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Exception\InvalidArgumentException;
+
+class PlatformFunction implements Operand
+{
+    /**
+     * @var string[]
+     */
+    private static $doctrine_functions = [
+        'IDENTITY',
+        'ABS',
+        'CONCAT',
+        'CURRENT_DATE',
+        'CURRENT_TIME',
+        'CURRENT_TIMESTAMP',
+        'LENGTH',
+        'LOCATE',
+        'LOWER',
+        'MOD',
+        'SIZE',
+        'SQRT',
+        'SUBSTRING',
+        'TRIM',
+        'UPPER',
+        'DATE_ADD',
+        'DATE_SUB',
+        'DATE_DIFF',
+    ];
+
+    /**
+     * @var string
+     */
+    private $functionName = '';
+
+    /**
+     * @var array
+     */
+    private $arguments = [];
+
+    /**
+     * @param string $functionName
+     * @param mixed  $arguments
+     */
+    public function __construct($functionName, $arguments = [])
+    {
+        if (func_num_args() === 2) {
+            $this->functionName = $functionName;
+            $this->arguments = (array) $arguments;
+        } else {
+            $arguments = func_get_args();
+            $this->functionName = array_shift($arguments);
+            $this->arguments = $arguments;
+        }
+    }
+
+    /**
+     * @param QueryBuilder $qb
+     * @param string       $dqlAlias
+     *
+     * @return string
+     */
+    public function transform(QueryBuilder $qb, $dqlAlias)
+    {
+        if (!in_array(strtoupper($this->functionName), self::$doctrine_functions) &&
+            !$qb->getEntityManager()->getConfiguration()->getCustomStringFunction($this->functionName) &&
+            !$qb->getEntityManager()->getConfiguration()->getCustomNumericFunction($this->functionName) &&
+            !$qb->getEntityManager()->getConfiguration()->getCustomDatetimeFunction($this->functionName)
+        ) {
+            throw new InvalidArgumentException(sprintf('"%s" is not a valid function name.', $this->functionName));
+        }
+
+        $arguments = ArgumentToOperandConverter::convert($this->arguments);
+        foreach ($arguments as $key => $argument) {
+            $arguments[$key] = $argument->transform($qb, $dqlAlias);
+        }
+
+        return sprintf('%s(%s)', $this->functionName, implode(', ', $arguments));
+    }
+}

--- a/src/Operand/PlatformFunction.php
+++ b/src/Operand/PlatformFunction.php
@@ -47,7 +47,7 @@ class PlatformFunction implements Operand
      */
     public function __construct($functionName, $arguments = [])
     {
-        if (func_num_args() === 2) {
+        if (2 === func_num_args()) {
             $this->functionName = $functionName;
             $this->arguments = (array) $arguments;
         } else {

--- a/src/Operand/PlatformFunction.php
+++ b/src/Operand/PlatformFunction.php
@@ -10,7 +10,7 @@ class PlatformFunction implements Operand
     /**
      * @var string[]
      */
-    private static $doctrine_functions = [
+    private static $doctrineFunctions = [
         'IDENTITY',
         'ABS',
         'CONCAT',
@@ -65,7 +65,7 @@ class PlatformFunction implements Operand
      */
     public function transform(QueryBuilder $qb, $dqlAlias)
     {
-        if (!in_array(strtoupper($this->functionName), self::$doctrine_functions) &&
+        if (!in_array(strtoupper($this->functionName), self::$doctrineFunctions) &&
             !$qb->getEntityManager()->getConfiguration()->getCustomStringFunction($this->functionName) &&
             !$qb->getEntityManager()->getConfiguration()->getCustomNumericFunction($this->functionName) &&
             !$qb->getEntityManager()->getConfiguration()->getCustomDatetimeFunction($this->functionName)

--- a/src/Spec.php
+++ b/src/Spec.php
@@ -57,6 +57,17 @@ use Happyr\DoctrineSpecification\Specification\Having;
  */
 class Spec
 {
+    /**
+     * @param string $name
+     * @param array  $arguments
+     *
+     * @return PlatformFunction
+     */
+    public static function __callStatic($name, array $arguments = [])
+    {
+        return self::fun($name, $arguments);
+    }
+
     /*
      * Logic
      */
@@ -457,16 +468,5 @@ class Spec
         $arguments = func_get_args();
 
         return new PlatformFunction(array_shift($arguments), $arguments);
-    }
-
-    /**
-     * @param string $name
-     * @param array  $arguments
-     *
-     * @return PlatformFunction
-     */
-    public static function __callStatic($name, array $arguments = [])
-    {
-        return self::fun($name, $arguments);
     }
 }

--- a/src/Spec.php
+++ b/src/Spec.php
@@ -15,6 +15,7 @@ use Happyr\DoctrineSpecification\Logic\OrX;
 use Happyr\DoctrineSpecification\Operand\Field;
 use Happyr\DoctrineSpecification\Operand\LikePattern;
 use Happyr\DoctrineSpecification\Operand\Operand;
+use Happyr\DoctrineSpecification\Operand\PlatformFunction;
 use Happyr\DoctrineSpecification\Operand\Value;
 use Happyr\DoctrineSpecification\Operand\Values;
 use Happyr\DoctrineSpecification\Query\GroupBy;
@@ -35,6 +36,24 @@ use Happyr\DoctrineSpecification\Specification\Having;
 
 /**
  * Factory class for the specifications.
+ *
+ * @method static PlatformFunction IDENTITY($expression, $fieldMapping = null) Retrieve the foreign key column of association of the owning side
+ * @method static PlatformFunction ABS($expression)
+ * @method static PlatformFunction CONCAT($str1, $str2)
+ * @method static PlatformFunction CURRENT_DATE() Return the current date
+ * @method static PlatformFunction CURRENT_TIME() Returns the current time
+ * @method static PlatformFunction CURRENT_TIMESTAMP() Returns a timestamp of the current date and time.
+ * @method static PlatformFunction LENGTH($str) Returns the length of the given string
+ * @method static PlatformFunction LOCATE($needle, $haystack, $offset = 0) Locate the first occurrence of the substring in the string.
+ * @method static PlatformFunction LOWER($str) Returns the string lowercased.
+ * @method static PlatformFunction SIZE($collection) Return the number of elements in the specified collection
+ * @method static PlatformFunction SQRT($q) Return the square-root of q.
+ * @method static PlatformFunction SUBSTRING($str, $start, $length = null) Return substring of given string.
+ * @method static PlatformFunction TRIM($str) Trim the string by the given trim char, defaults to whitespaces.
+ * @method static PlatformFunction UPPER($str) Return the upper-case of the given string.
+ * @method static PlatformFunction DATE_ADD($date, $days, $unit) Add the number of days to a given date. (Supported units are DAY, MONTH)
+ * @method static PlatformFunction DATE_SUB($date, $days, $unit) Substract the number of days from a given date. (Supported units are DAY, MONTH)
+ * @method static PlatformFunction DATE_DIFF($date1, $date2) Calculate the difference in days between date1-date2.
  */
 class Spec
 {
@@ -425,5 +444,29 @@ class Spec
     public static function likePattern($value, $format = LikePattern::CONTAINS)
     {
         return new LikePattern($value, $format);
+    }
+
+    /**
+     * @param string $functionName
+     * @param mixed  $arguments
+     *
+     * @return PlatformFunction
+     */
+    public static function fun($functionName, $arguments = [])
+    {
+        $arguments = func_get_args();
+
+        return new PlatformFunction(array_shift($arguments), $arguments);
+    }
+
+    /**
+     * @param string $name
+     * @param array  $arguments
+     *
+     * @return PlatformFunction
+     */
+    public static function __callStatic($name, array $arguments = [])
+    {
+        return self::fun($name, $arguments);
     }
 }

--- a/src/Spec.php
+++ b/src/Spec.php
@@ -37,23 +37,31 @@ use Happyr\DoctrineSpecification\Specification\Having;
 /**
  * Factory class for the specifications.
  *
- * @method static PlatformFunction IDENTITY($expression, $fieldMapping = null) Retrieve the foreign key column of association of the owning side
- * @method static PlatformFunction ABS($expression)
  * @method static PlatformFunction CONCAT($str1, $str2)
+ * @method static PlatformFunction SUBSTRING($str, $start, $length = null) Return substring of given string.
+ * @method static PlatformFunction TRIM($str) Trim the string by the given trim char, defaults to whitespaces.
+ * @method static PlatformFunction LOWER($str) Returns the string lowercased.
+ * @method static PlatformFunction UPPER($str) Return the upper-case of the given string.
+ * @method static PlatformFunction IDENTITY($expression, $fieldMapping = null) Retrieve the foreign key column of association of the owning side
+ * @method static PlatformFunction LENGTH($str) Returns the length of the given string
+ * @method static PlatformFunction LOCATE($needle, $haystack, $offset = 0) Locate the first occurrence of the substring in the string.
+ * @method static PlatformFunction ABS($expression)
+ * @method static PlatformFunction SQRT($q) Return the square-root of q.
+ * @method static PlatformFunction MOD($a, $b) Return a MOD b.
+ * @method static PlatformFunction SIZE($collection) Return the number of elements in the specified collection
+ * @method static PlatformFunction DATE_DIFF($date1, $date2) Calculate the difference in days between date1-date2.
+ * @method static PlatformFunction BIT_AND($a, $b)
+ * @method static PlatformFunction BIT_OR($a, $b)
+ * @method static PlatformFunction MIN($a)
+ * @method static PlatformFunction MAX($a)
+ * @method static PlatformFunction AVG($a)
+ * @method static PlatformFunction SUM($a)
+ * @method static PlatformFunction COUNT($a)
  * @method static PlatformFunction CURRENT_DATE() Return the current date
  * @method static PlatformFunction CURRENT_TIME() Returns the current time
  * @method static PlatformFunction CURRENT_TIMESTAMP() Returns a timestamp of the current date and time.
- * @method static PlatformFunction LENGTH($str) Returns the length of the given string
- * @method static PlatformFunction LOCATE($needle, $haystack, $offset = 0) Locate the first occurrence of the substring in the string.
- * @method static PlatformFunction LOWER($str) Returns the string lowercased.
- * @method static PlatformFunction SIZE($collection) Return the number of elements in the specified collection
- * @method static PlatformFunction SQRT($q) Return the square-root of q.
- * @method static PlatformFunction SUBSTRING($str, $start, $length = null) Return substring of given string.
- * @method static PlatformFunction TRIM($str) Trim the string by the given trim char, defaults to whitespaces.
- * @method static PlatformFunction UPPER($str) Return the upper-case of the given string.
  * @method static PlatformFunction DATE_ADD($date, $days, $unit) Add the number of days to a given date. (Supported units are DAY, MONTH)
  * @method static PlatformFunction DATE_SUB($date, $days, $unit) Substract the number of days from a given date. (Supported units are DAY, MONTH)
- * @method static PlatformFunction DATE_DIFF($date1, $date2) Calculate the difference in days between date1-date2.
  */
 class Spec
 {

--- a/tests/Operand/PlatformFunctionSpec.php
+++ b/tests/Operand/PlatformFunctionSpec.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace tests\Happyr\DoctrineSpecification\Operand;
+
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Operand\Field;
+use Happyr\DoctrineSpecification\Operand\PlatformFunction;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @mixin PlatformFunction
+ */
+class PlatformFunctionSpec extends ObjectBehavior
+{
+    private $functionName = 'UPPER';
+
+    private $arguments = 'foo';
+
+    public function let()
+    {
+        $this->beConstructedWith($this->functionName, $this->arguments);
+    }
+
+    public function it_is_a_platform_function()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\PlatformFunction');
+    }
+
+    public function it_is_a_operand()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Operand');
+    }
+
+    public function it_is_transformable_doctrine_function(QueryBuilder $qb)
+    {
+        $dqlAlias = 'a';
+        $expression = 'UPPER(a.foo)';
+
+        $this->transform($qb, $dqlAlias)->shouldReturn($expression);
+    }
+
+    public function it_is_transformable_many_arguments(QueryBuilder $qb)
+    {
+        $dqlAlias = 'a';
+        $expression = 'concat(a.foo, a.bar)';
+
+        $this->beConstructedWith('concat', new Field('foo'), new Field('bar'));
+
+        $this->transform($qb, $dqlAlias)->shouldReturn($expression);
+    }
+
+    public function it_is_transformable_custom_string_function(
+        QueryBuilder $qb,
+        EntityManagerInterface $em,
+        Configuration $configuration
+    ) {
+        $dqlAlias = 'a';
+        $functionName = 'foo';
+        $expression = 'foo(a.foo)';
+
+        $qb->getEntityManager()->willReturn($em);
+        $em->getConfiguration()->willReturn($configuration);
+        $configuration->getCustomStringFunction($functionName)->willReturn('ToStringClass');
+        $configuration->getCustomNumericFunction($functionName)->willReturn(null);
+        $configuration->getCustomDatetimeFunction($functionName)->willReturn(null);
+
+        $this->beConstructedWith($functionName, 'foo');
+
+        $this->transform($qb, $dqlAlias)->shouldReturn($expression);
+    }
+
+    public function it_is_transformable_custom_numeric_function(
+        QueryBuilder $qb,
+        EntityManagerInterface $em,
+        Configuration $configuration
+    ) {
+        $dqlAlias = 'a';
+        $functionName = 'foo';
+        $expression = 'foo(a.foo)';
+
+        $qb->getEntityManager()->willReturn($em);
+        $em->getConfiguration()->willReturn($configuration);
+        $configuration->getCustomStringFunction($functionName)->willReturn(null);
+        $configuration->getCustomNumericFunction($functionName)->willReturn('ToNumericClass');
+        $configuration->getCustomDatetimeFunction($functionName)->willReturn(null);
+
+        $this->beConstructedWith($functionName, 'foo');
+
+        $this->transform($qb, $dqlAlias)->shouldReturn($expression);
+    }
+
+    public function it_is_transformable_custom_datetime_function(
+        QueryBuilder $qb,
+        EntityManagerInterface $em,
+        Configuration $configuration
+    ) {
+        $dqlAlias = 'a';
+        $functionName = 'foo';
+        $expression = 'foo(a.foo)';
+
+        $qb->getEntityManager()->willReturn($em);
+        $em->getConfiguration()->willReturn($configuration);
+        $configuration->getCustomStringFunction($functionName)->willReturn(null);
+        $configuration->getCustomNumericFunction($functionName)->willReturn(null);
+        $configuration->getCustomDatetimeFunction($functionName)->willReturn('ToDatetimeClass');
+
+        $this->beConstructedWith($functionName, 'foo');
+
+        $this->transform($qb, $dqlAlias)->shouldReturn($expression);
+    }
+
+    public function it_is_transformable_undefined_function(
+        QueryBuilder $qb,
+        EntityManagerInterface $em,
+        Configuration $configuration
+    ) {
+        $functionName = 'foo';
+
+        $qb->getEntityManager()->willReturn($em);
+        $em->getConfiguration()->willReturn($configuration);
+        $configuration->getCustomStringFunction($functionName)->willReturn(null);
+        $configuration->getCustomNumericFunction($functionName)->willReturn(null);
+        $configuration->getCustomDatetimeFunction($functionName)->willReturn(null);
+
+        $this->beConstructedWith($functionName, 'foo');
+        $this->shouldThrow('Happyr\DoctrineSpecification\Exception\InvalidArgumentException')
+            ->during('transform', array($qb, 'a'));
+    }
+
+    public function it_is_transformable_not_convertible(QueryBuilder $qb)
+    {
+        $this->beConstructedWith('concat', ['foo', 'bar', 'baz']);
+
+        $this->shouldThrow('Happyr\DoctrineSpecification\Exception\NotConvertibleException')
+            ->during('transform', array($qb, 'a'));
+    }
+}

--- a/tests/SpecSpec.php
+++ b/tests/SpecSpec.php
@@ -14,4 +14,14 @@ class SpecSpec extends ObjectBehavior
     {
         $this->andX()->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Logic\LogicX');
     }
+
+    public function it_creates_an_function()
+    {
+        $this->fun('UPPER', 'foo')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Operand\PlatformFunction');
+    }
+
+    public function it_creates_an_magic_function()
+    {
+        $this->__callStatic('UPPER', ['foo'])->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Operand\PlatformFunction');
+    }
 }


### PR DESCRIPTION
This is a implementation of the Function operand from #169 feature.

Use functions:

```php
// DQL: SIZE(e.products) > 2
Spec::gt(Spec::SIZE('products'), 2);
// or
Spec::gt(Spec::fun('SIZE', 'products'), 2);
// or
Spec::gt(Spec::fun('SIZE', Spec::field('products')), 2);
```

Nested functions:

```php
// DQL: TRIM(LOWER(e.email)) = :email
Spec::eq(Spec::TRIM(Spec::LOWER('email')), trim(strtolower($email)));
// or
Spec::eq(
    Spec::fun('TRIM', Spec::fun('LOWER', Spec::field('email'))),
    trim(strtolower($email))
);
```