### PR TITLE
Add scalar shortcut methods to repository

### DIFF
--- a/src/EntitySpecificationRepositoryInterface.php
+++ b/src/EntitySpecificationRepositoryInterface.php
@@ -49,6 +49,32 @@ interface EntitySpecificationRepositoryInterface
     public function matchOneOrNullResult($specification, ResultModifier $modifier = null);
 
     /**
+     * Get single scalar result when you match with a Specification.
+     *
+     * @param Filter|QueryModifier $specification
+     * @param ResultModifier|null  $modifier
+     *
+     * @throw Exception\NonUniqueException  If more than one result is found
+     * @throw Exception\NoResultException   If no results found
+     *
+     * @return mixed
+     */
+    public function matchSingleScalarResult($specification, ResultModifier $modifier = null);
+
+    /**
+     * Get scalar result when you match with a Specification.
+     *
+     * @param Filter|QueryModifier $specification
+     * @param ResultModifier|null  $modifier
+     *
+     * @throw Exception\NonUniqueException  If more than one result is found
+     * @throw Exception\NoResultException   If no results found
+     *
+     * @return mixed
+     */
+    public function matchScalarResult($specification, ResultModifier $modifier = null);
+
+    /**
      * Prepare a Query with a Specification.
      *
      * @param Filter|QueryModifier $specification

--- a/src/EntitySpecificationRepositoryTrait.php
+++ b/src/EntitySpecificationRepositoryTrait.php
@@ -79,6 +79,54 @@ trait EntitySpecificationRepositoryTrait
     }
 
     /**
+     * Get single scalar result when you match with a Specification.
+     *
+     * @param Filter|QueryModifier $specification
+     * @param ResultModifier|null  $modifier
+     *
+     * @throw Exception\NonUniqueException  If more than one result is found
+     * @throw Exception\NoResultException   If no results found
+     *
+     * @return mixed
+     */
+    public function matchSingleScalarResult($specification, ResultModifier $modifier = null)
+    {
+        $query = $this->getQuery($specification, $modifier);
+
+        try {
+            return $query->getSingleScalarResult();
+        } catch (NonUniqueResultException $e) {
+            throw new Exception\NonUniqueResultException($e->getMessage(), $e->getCode(), $e);
+        } catch (NoResultException $e) {
+            throw new Exception\NoResultException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+
+    /**
+     * Get scalar result when you match with a Specification.
+     *
+     * @param Filter|QueryModifier $specification
+     * @param ResultModifier|null  $modifier
+     *
+     * @throw Exception\NonUniqueException  If more than one result is found
+     * @throw Exception\NoResultException   If no results found
+     *
+     * @return mixed
+     */
+    public function matchScalarResult($specification, ResultModifier $modifier = null)
+    {
+        $query = $this->getQuery($specification, $modifier);
+
+        try {
+            return $query->getScalarResult();
+        } catch (NonUniqueResultException $e) {
+            throw new Exception\NonUniqueResultException($e->getMessage(), $e->getCode(), $e);
+        } catch (NoResultException $e) {
+            throw new Exception\NoResultException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+
+    /**
      * Prepare a Query with a Specification.
      *
      * @param Filter|QueryModifier $specification

--- a/tests/EntitySpecificationRepositorySpec.php
+++ b/tests/EntitySpecificationRepositorySpec.php
@@ -167,6 +167,100 @@ class EntitySpecificationRepositorySpec extends ObjectBehavior
         $this->shouldThrow('Happyr\DoctrineSpecification\Exception\NonUniqueResultException')->duringMatchSingleResult($specification);
     }
 
+    public function it_matches_a_single_scalar_result_without_result_modifier(
+        Specification $specification,
+        EntityManager $entityManager,
+        QueryBuilder $qb,
+        AbstractQuery $query
+    ) {
+        $singleScalarResult = '1';
+
+        $this->prepareStubs($specification, $entityManager, $qb, $query);
+
+        $specification->modify($qb, $this->alias)->shouldBeCalled();
+
+        $query->getSingleScalarResult()->willReturn($singleScalarResult);
+
+        $this->matchSingleScalarResult($specification)->shouldReturn($singleScalarResult);
+    }
+
+    public function it_throws_exception_when_expecting_single_scalar_result_finding_none_without_result_modifier(
+        Specification $specification,
+        EntityManager $entityManager,
+        QueryBuilder $qb,
+        AbstractQuery $query
+    ) {
+        $this->prepareStubs($specification, $entityManager, $qb, $query);
+
+        $specification->modify($qb, $this->alias)->shouldBeCalled();
+
+        $query->getSingleScalarResult()->willThrow(new NoResultException());
+
+        $this->shouldThrow('Happyr\DoctrineSpecification\Exception\NoResultException')->duringMatchSingleScalarResult($specification);
+    }
+
+    public function it_throws_exception_when_expecting_single_scalar_result_finding_multiple_without_result_modifier(
+        Specification $specification,
+        EntityManager $entityManager,
+        QueryBuilder $qb,
+        AbstractQuery $query
+    ) {
+        $this->prepareStubs($specification, $entityManager, $qb, $query);
+
+        $specification->modify($qb, $this->alias)->shouldBeCalled();
+
+        $query->getSingleScalarResult()->willThrow(new NonUniqueResultException());
+
+        $this->shouldThrow('Happyr\DoctrineSpecification\Exception\NonUniqueResultException')->duringMatchSingleScalarResult($specification);
+    }
+
+    public function it_matches_a_scalar_result_when_expecting_one_or_null_without_result_modifier(
+        Specification $specification,
+        EntityManager $entityManager,
+        QueryBuilder $qb,
+        AbstractQuery $query
+    ) {
+        $scalarResult = ['1', '2', '3'];
+
+        $this->prepareStubs($specification, $entityManager, $qb, $query);
+
+        $specification->modify($qb, $this->alias)->shouldBeCalled();
+
+        $query->getScalarResult()->willReturn($scalarResult);
+
+        $this->matchScalarResult($specification)->shouldReturn($scalarResult);
+    }
+
+    public function it_throws_exception_when_expecting_scalar_result_finding_none_without_result_modifier(
+        Specification $specification,
+        EntityManager $entityManager,
+        QueryBuilder $qb,
+        AbstractQuery $query
+    ) {
+        $this->prepareStubs($specification, $entityManager, $qb, $query);
+
+        $specification->modify($qb, $this->alias)->shouldBeCalled();
+
+        $query->getScalarResult()->willThrow(new NoResultException());
+
+        $this->shouldThrow('Happyr\DoctrineSpecification\Exception\NoResultException')->duringMatchScalarResult($specification);
+    }
+
+    public function it_throws_exception_when_expecting_scalar_result_finding_multiple_without_result_modifier(
+        Specification $specification,
+        EntityManager $entityManager,
+        QueryBuilder $qb,
+        AbstractQuery $query
+    ) {
+        $this->prepareStubs($specification, $entityManager, $qb, $query);
+
+        $specification->modify($qb, $this->alias)->shouldBeCalled();
+
+        $query->getScalarResult()->willThrow(new NonUniqueResultException());
+
+        $this->shouldThrow('Happyr\DoctrineSpecification\Exception\NonUniqueResultException')->duringMatchScalarResult($specification);
+    }
+
     public function it_matches_a_single_result_when_expecting_one_or_null_without_result_modifier(
         Specification $specification,
         EntityManager $entityManager,


### PR DESCRIPTION
Doctrine [AbstractQuery](https://github.com/doctrine/orm/blob/master/lib/Doctrine/ORM/AbstractQuery.php) has two scalar shortcut methods, would it be an idea to add them to this library? I'm aware the same result can be achieved by using result modifiers, but sometimes these shortcut methods come in handy.