### PR TITLE
Use ::class const for optimization

### DIFF
--- a/src/EntitySpecificationRepositoryTrait.php
+++ b/src/EntitySpecificationRepositoryTrait.php
@@ -202,8 +202,8 @@ trait EntitySpecificationRepositoryTrait
         if (!$specification instanceof QueryModifier && !$specification instanceof Filter) {
             throw new \InvalidArgumentException(sprintf(
                 'Expected argument of type "%s" or "%s", "%s" given.',
-                'Happyr\DoctrineSpecification\Query\QueryModifier',
-                'Happyr\DoctrineSpecification\Filter\Filter',
+                QueryModifier::class,
+                Filter::class,
                 is_object($specification) ? get_class($specification) : gettype($specification)
             ));
         }

--- a/src/Query/QueryModifierCollection.php
+++ b/src/Query/QueryModifierCollection.php
@@ -29,8 +29,7 @@ class QueryModifierCollection implements QueryModifier
         foreach ($this->children as $child) {
             if (!$child instanceof QueryModifier) {
                 throw new InvalidArgumentException(sprintf(
-                    'Child passed to %s must be an instance of %s, but instance of %s found',
-                    QueryModifierCollection::class,
+                    'Child passed to QueryModifierCollection must be an instance of %s, but instance of %s found',
                     QueryModifier::class,
                     get_class($child)
                 ));

--- a/src/Query/QueryModifierCollection.php
+++ b/src/Query/QueryModifierCollection.php
@@ -28,12 +28,12 @@ class QueryModifierCollection implements QueryModifier
     {
         foreach ($this->children as $child) {
             if (!$child instanceof QueryModifier) {
-                throw new InvalidArgumentException(
-                    sprintf(
-                        'Child passed to QueryModifierCollection must be an instance of Happyr\DoctrineSpecification\Query\QueryModifier, but instance of %s found',
-                        get_class($child)
-                    )
-                );
+                throw new InvalidArgumentException(sprintf(
+                    'Child passed to %s must be an instance of %s, but instance of %s found',
+                    QueryModifierCollection::class,
+                    QueryModifier::class,
+                    get_class($child)
+                ));
             }
 
             $child->modify($qb, $dqlAlias);

--- a/src/Result/ResultModifierCollection.php
+++ b/src/Result/ResultModifierCollection.php
@@ -27,12 +27,12 @@ class ResultModifierCollection implements ResultModifier
     {
         foreach ($this->children as $child) {
             if (!$child instanceof ResultModifier) {
-                throw new InvalidArgumentException(
-                    sprintf(
-                        'Child passed to ResultModifierCollection must be an instance of Happyr\DoctrineSpecification\Result\ResultModifier, but instance of %s found',
-                        get_class($child)
-                    )
-                );
+                throw new InvalidArgumentException(sprintf(
+                    'Child passed to %s must be an instance of %s, but instance of %s found',
+                    ResultModifierCollection::class,
+                    ResultModifier::class,
+                    get_class($child)
+                ));
             }
 
             $child->modify($query);

--- a/src/Result/ResultModifierCollection.php
+++ b/src/Result/ResultModifierCollection.php
@@ -28,8 +28,7 @@ class ResultModifierCollection implements ResultModifier
         foreach ($this->children as $child) {
             if (!$child instanceof ResultModifier) {
                 throw new InvalidArgumentException(sprintf(
-                    'Child passed to %s must be an instance of %s, but instance of %s found',
-                    ResultModifierCollection::class,
+                    'Child passed to ResultModifierCollection must be an instance of %s, but instance of %s found',
                     ResultModifier::class,
                     get_class($child)
                 ));

--- a/src/Spec.php
+++ b/src/Spec.php
@@ -103,7 +103,7 @@ class Spec
     public static function andX()
     {
         $args = func_get_args();
-        $reflection = new \ReflectionClass('Happyr\DoctrineSpecification\Logic\AndX');
+        $reflection = new \ReflectionClass(AndX::class);
 
         return $reflection->newInstanceArgs($args);
     }
@@ -114,7 +114,7 @@ class Spec
     public static function orX()
     {
         $args = func_get_args();
-        $reflection = new \ReflectionClass('Happyr\DoctrineSpecification\Logic\OrX');
+        $reflection = new \ReflectionClass(OrX::class);
 
         return $reflection->newInstanceArgs($args);
     }

--- a/tests/EntitySpecificationRepositorySpec.php
+++ b/tests/EntitySpecificationRepositorySpec.php
@@ -5,10 +5,13 @@ namespace tests\Happyr\DoctrineSpecification;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\NonUniqueResultException;
-use Doctrine\ORM\NoResultException;
+use Doctrine\ORM\NonUniqueResultException as DoctrineNonUniqueResultException;
+use Doctrine\ORM\NoResultException as DoctrineNoResultException;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\EntitySpecificationRepository;
+use Happyr\DoctrineSpecification\Exception\NonUniqueResultException;
+use Happyr\DoctrineSpecification\Exception\NoResultException;
+use Happyr\DoctrineSpecification\Exception\UnexpectedResultException;
 use Happyr\DoctrineSpecification\Filter\Filter;
 use Happyr\DoctrineSpecification\Query\QueryModifier;
 use Happyr\DoctrineSpecification\Result\ResultModifier;
@@ -147,9 +150,9 @@ class EntitySpecificationRepositorySpec extends ObjectBehavior
 
         $specification->modify($qb, $this->alias)->shouldBeCalled();
 
-        $query->getSingleResult()->willThrow(new NoResultException());
+        $query->getSingleResult()->willThrow(new DoctrineNoResultException());
 
-        $this->shouldThrow('Happyr\DoctrineSpecification\Exception\NoResultException')->duringMatchSingleResult($specification);
+        $this->shouldThrow(NoResultException::class)->duringMatchSingleResult($specification);
     }
 
     public function it_throws_exception_when_expecting_single_result_finding_multiple_without_result_modifier(
@@ -162,9 +165,9 @@ class EntitySpecificationRepositorySpec extends ObjectBehavior
 
         $specification->modify($qb, $this->alias)->shouldBeCalled();
 
-        $query->getSingleResult()->willThrow(new NonUniqueResultException());
+        $query->getSingleResult()->willThrow(new DoctrineNonUniqueResultException());
 
-        $this->shouldThrow('Happyr\DoctrineSpecification\Exception\NonUniqueResultException')->duringMatchSingleResult($specification);
+        $this->shouldThrow(NonUniqueResultException::class)->duringMatchSingleResult($specification);
     }
 
     public function it_matches_a_single_scalar_result_without_result_modifier(
@@ -194,9 +197,9 @@ class EntitySpecificationRepositorySpec extends ObjectBehavior
 
         $specification->modify($qb, $this->alias)->shouldBeCalled();
 
-        $query->getSingleScalarResult()->willThrow(new NonUniqueResultException());
+        $query->getSingleScalarResult()->willThrow(new DoctrineNonUniqueResultException());
 
-        $this->shouldThrow('Happyr\DoctrineSpecification\Exception\NonUniqueResultException')->duringMatchSingleScalarResult($specification);
+        $this->shouldThrow(NonUniqueResultException::class)->duringMatchSingleScalarResult($specification);
     }
 
     public function it_matches_a_scalar_result_when_expecting_one_or_null_without_result_modifier(
@@ -243,9 +246,9 @@ class EntitySpecificationRepositorySpec extends ObjectBehavior
 
         $specification->modify($qb, $this->alias)->shouldBeCalled();
 
-        $query->getSingleResult()->willThrow(new NonUniqueResultException());
+        $query->getSingleResult()->willThrow(new DoctrineNonUniqueResultException());
 
-        $this->shouldThrow('Happyr\DoctrineSpecification\Exception\NonUniqueResultException')->duringMatchOneOrNullResult($specification);
+        $this->shouldThrow(NonUniqueResultException::class)->duringMatchOneOrNullResult($specification);
     }
 
     public function it_throws_exception_when_expecting_one_or_null_finding_multiple_without_result_modifier(
@@ -258,9 +261,9 @@ class EntitySpecificationRepositorySpec extends ObjectBehavior
 
         $specification->modify($qb, $this->alias)->shouldBeCalled();
 
-        $query->getSingleResult()->willThrow(new NonUniqueResultException());
+        $query->getSingleResult()->willThrow(new DoctrineNonUniqueResultException());
 
-        $this->shouldThrow('Happyr\DoctrineSpecification\Exception\UnexpectedResultException')->duringMatchOneOrNullResult($specification);
+        $this->shouldThrow(UnexpectedResultException::class)->duringMatchOneOrNullResult($specification);
     }
 
     public function it_matches_a_specification_with_result_modifier(

--- a/tests/Filter/ComparisonSpec.php
+++ b/tests/Filter/ComparisonSpec.php
@@ -4,7 +4,9 @@ namespace tests\Happyr\DoctrineSpecification\Filter;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Exception\InvalidArgumentException;
 use Happyr\DoctrineSpecification\Filter\Comparison;
+use Happyr\DoctrineSpecification\Filter\Filter;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -19,7 +21,7 @@ class ComparisonSpec extends ObjectBehavior
 
     public function it_is_an_expression()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Filter\Filter');
+        $this->shouldBeAnInstanceOf(Filter::class);
     }
 
     public function it_returns_comparison_object(QueryBuilder $qb, ArrayCollection $parameters)
@@ -48,11 +50,11 @@ class ComparisonSpec extends ObjectBehavior
 
     public function it_validates_operator()
     {
-        $this->shouldThrow('Happyr\DoctrineSpecification\Exception\InvalidArgumentException')->during('__construct', array('==', 'age', 18, null));
+        $this->shouldThrow(InvalidArgumentException::class)->during('__construct', array('==', 'age', 18, null));
     }
 
     public function it_not_support_like_operator()
     {
-        $this->shouldThrow('Happyr\DoctrineSpecification\Exception\InvalidArgumentException')->during('__construct', array('like', 'name', 'Tobias%', null));
+        $this->shouldThrow(InvalidArgumentException::class)->during('__construct', array('like', 'name', 'Tobias%', null));
     }
 }

--- a/tests/Filter/InSpec.php
+++ b/tests/Filter/InSpec.php
@@ -5,6 +5,7 @@ namespace tests\Happyr\DoctrineSpecification\Filter;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Filter\Filter;
 use Happyr\DoctrineSpecification\Filter\In;
 use PhpSpec\ObjectBehavior;
 
@@ -24,7 +25,7 @@ class InSpec extends ObjectBehavior
 
     public function it_is_an_expression()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Filter\Filter');
+        $this->shouldBeAnInstanceOf(Filter::class);
     }
 
     public function it_returns_expression_func_object(QueryBuilder $qb, ArrayCollection $parameters, Expr $expr)

--- a/tests/Filter/InstanceOfXSpec.php
+++ b/tests/Filter/InstanceOfXSpec.php
@@ -3,6 +3,7 @@
 namespace tests\Happyr\DoctrineSpecification\Filter;
 
 use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Filter\Filter;
 use Happyr\DoctrineSpecification\Filter\InstanceOfX;
 use PhpSpec\ObjectBehavior;
 
@@ -18,12 +19,12 @@ class InstanceOfXSpec extends ObjectBehavior
 
     public function it_is_initializable()
     {
-        $this->shouldHaveType('Happyr\DoctrineSpecification\Filter\InstanceOfX');
+        $this->shouldHaveType(InstanceOfX::class);
     }
 
     public function it_is_an_expression()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Filter\Filter');
+        $this->shouldBeAnInstanceOf(Filter::class);
     }
 
     public function it_returns_expression_func_object(QueryBuilder $qb)

--- a/tests/Filter/IsNotNullSpec.php
+++ b/tests/Filter/IsNotNullSpec.php
@@ -4,6 +4,7 @@ namespace tests\Happyr\DoctrineSpecification\Filter;
 
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Filter\Filter;
 use Happyr\DoctrineSpecification\Filter\IsNotNull;
 use PhpSpec\ObjectBehavior;
 
@@ -23,7 +24,7 @@ class IsNotNullSpec extends ObjectBehavior
 
     public function it_is_an_expression()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Filter\Filter');
+        $this->shouldBeAnInstanceOf(Filter::class);
     }
 
     /**

--- a/tests/Filter/IsNullSpec.php
+++ b/tests/Filter/IsNullSpec.php
@@ -4,6 +4,7 @@ namespace tests\Happyr\DoctrineSpecification\Filter;
 
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Filter\Filter;
 use Happyr\DoctrineSpecification\Filter\IsNull;
 use PhpSpec\ObjectBehavior;
 
@@ -23,7 +24,7 @@ class IsNullSpec extends ObjectBehavior
 
     public function it_is_an_expression()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Filter\Filter');
+        $this->shouldBeAnInstanceOf(Filter::class);
     }
 
     /**

--- a/tests/Filter/LikeSpec.php
+++ b/tests/Filter/LikeSpec.php
@@ -5,6 +5,7 @@ namespace tests\Happyr\DoctrineSpecification\Spec;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Filter\Like;
+use Happyr\DoctrineSpecification\Specification\Specification;
 use PhpSpec\ObjectBehavior;
 
 class LikeSpec extends ObjectBehavior
@@ -20,7 +21,7 @@ class LikeSpec extends ObjectBehavior
 
     public function it_is_a_specification()
     {
-        $this->shouldHaveType('Happyr\DoctrineSpecification\Specification\Specification');
+        $this->shouldHaveType(Specification::class);
     }
 
     public function it_surrounds_with_wildcards_when_using_contains(QueryBuilder $qb, ArrayCollection $parameters)

--- a/tests/Filter/SliceSpec.php
+++ b/tests/Filter/SliceSpec.php
@@ -3,6 +3,7 @@
 namespace tests\Happyr\DoctrineSpecification\Query;
 
 use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Query\QueryModifier;
 use Happyr\DoctrineSpecification\Query\Slice;
 use PhpSpec\ObjectBehavior;
 
@@ -23,7 +24,7 @@ class SliceSpec extends ObjectBehavior
 
     public function it_is_a_specification()
     {
-        $this->shouldHaveType('Happyr\DoctrineSpecification\Query\QueryModifier');
+        $this->shouldHaveType(QueryModifier::class);
     }
 
     public function it_slice_with_zero_index(QueryBuilder $qb)

--- a/tests/Logic/LogicXSpec.php
+++ b/tests/Logic/LogicXSpec.php
@@ -23,7 +23,7 @@ class LogicXSpec extends ObjectBehavior
 
     public function it_is_a_specification()
     {
-        $this->shouldHaveType('Happyr\DoctrineSpecification\Specification\Specification');
+        $this->shouldHaveType(Specification::class);
     }
 
     public function it_modifies_all_child_queries(QueryBuilder $queryBuilder, Specification $specificationA, Specification $specificationB)

--- a/tests/Operand/AdditionSpec.php
+++ b/tests/Operand/AdditionSpec.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Operand\Addition;
 use Happyr\DoctrineSpecification\Operand\Field;
+use Happyr\DoctrineSpecification\Operand\Operand;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -24,12 +25,12 @@ class AdditionSpec extends ObjectBehavior
 
     public function it_is_a_add()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Addition');
+        $this->shouldBeAnInstanceOf(Addition::class);
     }
 
     public function it_is_a_operand()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Operand');
+        $this->shouldBeAnInstanceOf(Operand::class);
     }
 
     public function it_is_transformable(QueryBuilder $qb, ArrayCollection $parameters)

--- a/tests/Operand/AliasSpec.php
+++ b/tests/Operand/AliasSpec.php
@@ -4,6 +4,7 @@ namespace tests\Happyr\DoctrineSpecification\Operand;
 
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Operand\Alias;
+use Happyr\DoctrineSpecification\Operand\Operand;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -20,12 +21,12 @@ class AliasSpec extends ObjectBehavior
 
     public function it_is_a_alias()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Alias');
+        $this->shouldBeAnInstanceOf(Alias::class);
     }
 
     public function it_is_a_operand()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Operand');
+        $this->shouldBeAnInstanceOf(Operand::class);
     }
 
     public function it_is_transformable(QueryBuilder $qb)

--- a/tests/Operand/ArgumentToOperandConverterSpec.php
+++ b/tests/Operand/ArgumentToOperandConverterSpec.php
@@ -2,6 +2,7 @@
 
 namespace tests\Happyr\DoctrineSpecification\Operand;
 
+use Happyr\DoctrineSpecification\Exception\NotConvertibleException;
 use Happyr\DoctrineSpecification\Operand\ArgumentToOperandConverter;
 use Happyr\DoctrineSpecification\Operand\Field;
 use Happyr\DoctrineSpecification\Operand\Operand;
@@ -15,7 +16,7 @@ class ArgumentToOperandConverterSpec extends ObjectBehavior
 {
     public function it_is_a_converter()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\ArgumentToOperandConverter');
+        $this->shouldBeAnInstanceOf(ArgumentToOperandConverter::class);
     }
 
     public function it_not_convert_operand_to_field(Operand $operand)
@@ -25,7 +26,7 @@ class ArgumentToOperandConverterSpec extends ObjectBehavior
 
     public function it_convert_argument_to_field()
     {
-        $this->toField('foo')->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Field');
+        $this->toField('foo')->shouldBeAnInstanceOf(Field::class);
     }
 
     public function it_not_convert_operand_to_value(Operand $operand)
@@ -35,7 +36,7 @@ class ArgumentToOperandConverterSpec extends ObjectBehavior
 
     public function it_convert_argument_to_value()
     {
-        $this->toValue('foo')->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Value');
+        $this->toValue('foo')->shouldBeAnInstanceOf(Value::class);
     }
 
     public function it_is_all_arguments_a_operands(Operand $first, Operand $second)
@@ -104,7 +105,7 @@ class ArgumentToOperandConverterSpec extends ObjectBehavior
 
     public function it_is_not_convertible_arguments(Field $field, Operand $operand, Value $value)
     {
-        $this->shouldThrow('Happyr\DoctrineSpecification\Exception\NotConvertibleException')
+        $this->shouldThrow(NotConvertibleException::class)
             ->duringConvert(array($field, $operand, 'foo', $value));
     }
 

--- a/tests/Operand/BitAndSpec.php
+++ b/tests/Operand/BitAndSpec.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Operand\BitAnd;
 use Happyr\DoctrineSpecification\Operand\Field;
+use Happyr\DoctrineSpecification\Operand\Operand;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -24,12 +25,12 @@ class BitAndSpec extends ObjectBehavior
 
     public function it_is_a_bit_and()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\BitAnd');
+        $this->shouldBeAnInstanceOf(BitAnd::class);
     }
 
     public function it_is_a_operand()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Operand');
+        $this->shouldBeAnInstanceOf(Operand::class);
     }
 
     public function it_is_transformable(QueryBuilder $qb, ArrayCollection $parameters)

--- a/tests/Operand/BitLeftShiftSpec.php
+++ b/tests/Operand/BitLeftShiftSpec.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Operand\BitLeftShift;
 use Happyr\DoctrineSpecification\Operand\Field;
+use Happyr\DoctrineSpecification\Operand\Operand;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -24,12 +25,12 @@ class BitLeftShiftSpec extends ObjectBehavior
 
     public function it_is_a_bit_left_shift()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\BitLeftShift');
+        $this->shouldBeAnInstanceOf(BitLeftShift::class);
     }
 
     public function it_is_a_operand()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Operand');
+        $this->shouldBeAnInstanceOf(Operand::class);
     }
 
     public function it_is_transformable(QueryBuilder $qb, ArrayCollection $parameters)

--- a/tests/Operand/BitNotSpec.php
+++ b/tests/Operand/BitNotSpec.php
@@ -4,6 +4,7 @@ namespace tests\Happyr\DoctrineSpecification\Operand;
 
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Operand\BitNot;
+use Happyr\DoctrineSpecification\Operand\Operand;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -20,12 +21,12 @@ class BitNotSpec extends ObjectBehavior
 
     public function it_is_a_bit_not()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\BitNot');
+        $this->shouldBeAnInstanceOf(BitNot::class);
     }
 
     public function it_is_a_operand()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Operand');
+        $this->shouldBeAnInstanceOf(Operand::class);
     }
 
     public function it_is_transformable(QueryBuilder $qb)

--- a/tests/Operand/BitOrSpec.php
+++ b/tests/Operand/BitOrSpec.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Operand\BitOr;
 use Happyr\DoctrineSpecification\Operand\Field;
+use Happyr\DoctrineSpecification\Operand\Operand;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -24,12 +25,12 @@ class BitOrSpec extends ObjectBehavior
 
     public function it_is_a_bit_or()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\BitOr');
+        $this->shouldBeAnInstanceOf(BitOr::class);
     }
 
     public function it_is_a_operand()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Operand');
+        $this->shouldBeAnInstanceOf(Operand::class);
     }
 
     public function it_is_transformable(QueryBuilder $qb, ArrayCollection $parameters)

--- a/tests/Operand/BitRightShiftSpec.php
+++ b/tests/Operand/BitRightShiftSpec.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Operand\BitRightShift;
 use Happyr\DoctrineSpecification\Operand\Field;
+use Happyr\DoctrineSpecification\Operand\Operand;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -24,12 +25,12 @@ class BitRightShiftSpec extends ObjectBehavior
 
     public function it_is_a_bit_right_shift()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\BitRightShift');
+        $this->shouldBeAnInstanceOf(BitRightShift::class);
     }
 
     public function it_is_a_operand()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Operand');
+        $this->shouldBeAnInstanceOf(Operand::class);
     }
 
     public function it_is_transformable(QueryBuilder $qb, ArrayCollection $parameters)

--- a/tests/Operand/BitXorSpec.php
+++ b/tests/Operand/BitXorSpec.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Operand\BitXor;
 use Happyr\DoctrineSpecification\Operand\Field;
+use Happyr\DoctrineSpecification\Operand\Operand;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -24,12 +25,12 @@ class BitXorSpec extends ObjectBehavior
 
     public function it_is_a_bit_xor()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\BitXor');
+        $this->shouldBeAnInstanceOf(BitXor::class);
     }
 
     public function it_is_a_operand()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Operand');
+        $this->shouldBeAnInstanceOf(Operand::class);
     }
 
     public function it_is_transformable(QueryBuilder $qb, ArrayCollection $parameters)

--- a/tests/Operand/DivisionSpec.php
+++ b/tests/Operand/DivisionSpec.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Operand\Division;
 use Happyr\DoctrineSpecification\Operand\Field;
+use Happyr\DoctrineSpecification\Operand\Operand;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -24,12 +25,12 @@ class DivisionSpec extends ObjectBehavior
 
     public function it_is_a_div()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Division');
+        $this->shouldBeAnInstanceOf(Division::class);
     }
 
     public function it_is_a_operand()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Operand');
+        $this->shouldBeAnInstanceOf(Operand::class);
     }
 
     public function it_is_transformable(QueryBuilder $qb, ArrayCollection $parameters)

--- a/tests/Operand/FieldSpec.php
+++ b/tests/Operand/FieldSpec.php
@@ -4,6 +4,7 @@ namespace tests\Happyr\DoctrineSpecification\Operand;
 
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Operand\Field;
+use Happyr\DoctrineSpecification\Operand\Operand;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -20,12 +21,12 @@ class FieldSpec extends ObjectBehavior
 
     public function it_is_a_field()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Field');
+        $this->shouldBeAnInstanceOf(Field::class);
     }
 
     public function it_is_a_operand()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Operand');
+        $this->shouldBeAnInstanceOf(Operand::class);
     }
 
     public function it_is_transformable(QueryBuilder $qb)

--- a/tests/Operand/LikePatternSpec.php
+++ b/tests/Operand/LikePatternSpec.php
@@ -5,6 +5,7 @@ namespace tests\Happyr\DoctrineSpecification\Operand;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Operand\LikePattern;
+use Happyr\DoctrineSpecification\Operand\Operand;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -23,12 +24,12 @@ class LikePatternSpec extends ObjectBehavior
 
     public function it_is_a_like_pattern()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\LikePattern');
+        $this->shouldBeAnInstanceOf(LikePattern::class);
     }
 
     public function it_is_a_operand()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Operand');
+        $this->shouldBeAnInstanceOf(Operand::class);
     }
 
     public function it_is_transformable(QueryBuilder $qb, ArrayCollection $parameters)

--- a/tests/Operand/ModuloSpec.php
+++ b/tests/Operand/ModuloSpec.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Operand\Modulo;
 use Happyr\DoctrineSpecification\Operand\Field;
+use Happyr\DoctrineSpecification\Operand\Operand;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -24,12 +25,12 @@ class ModuloSpec extends ObjectBehavior
 
     public function it_is_a_mod()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Modulo');
+        $this->shouldBeAnInstanceOf(Modulo::class);
     }
 
     public function it_is_a_operand()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Operand');
+        $this->shouldBeAnInstanceOf(Operand::class);
     }
 
     public function it_is_transformable(QueryBuilder $qb, ArrayCollection $parameters)

--- a/tests/Operand/MultiplicationSpec.php
+++ b/tests/Operand/MultiplicationSpec.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Operand\Multiplication;
 use Happyr\DoctrineSpecification\Operand\Field;
+use Happyr\DoctrineSpecification\Operand\Operand;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -24,12 +25,12 @@ class MultiplicationSpec extends ObjectBehavior
 
     public function it_is_a_mul()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Multiplication');
+        $this->shouldBeAnInstanceOf(Multiplication::class);
     }
 
     public function it_is_a_operand()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Operand');
+        $this->shouldBeAnInstanceOf(Operand::class);
     }
 
     public function it_is_transformable(QueryBuilder $qb, ArrayCollection $parameters)

--- a/tests/Operand/PlatformFunctionSpec.php
+++ b/tests/Operand/PlatformFunctionSpec.php
@@ -5,7 +5,10 @@ namespace tests\Happyr\DoctrineSpecification\Operand;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Exception\InvalidArgumentException;
+use Happyr\DoctrineSpecification\Exception\NotConvertibleException;
 use Happyr\DoctrineSpecification\Operand\Field;
+use Happyr\DoctrineSpecification\Operand\Operand;
 use Happyr\DoctrineSpecification\Operand\PlatformFunction;
 use PhpSpec\ObjectBehavior;
 
@@ -25,12 +28,12 @@ class PlatformFunctionSpec extends ObjectBehavior
 
     public function it_is_a_platform_function()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\PlatformFunction');
+        $this->shouldBeAnInstanceOf(PlatformFunction::class);
     }
 
     public function it_is_a_operand()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Operand');
+        $this->shouldBeAnInstanceOf(Operand::class);
     }
 
     public function it_is_transformable_doctrine_function(QueryBuilder $qb)
@@ -125,15 +128,13 @@ class PlatformFunctionSpec extends ObjectBehavior
         $configuration->getCustomDatetimeFunction($functionName)->willReturn(null);
 
         $this->beConstructedWith($functionName, 'foo');
-        $this->shouldThrow('Happyr\DoctrineSpecification\Exception\InvalidArgumentException')
-            ->during('transform', array($qb, 'a'));
+        $this->shouldThrow(InvalidArgumentException::class)->during('transform', array($qb, 'a'));
     }
 
     public function it_is_transformable_not_convertible(QueryBuilder $qb)
     {
         $this->beConstructedWith('concat', ['foo', 'bar', 'baz']);
 
-        $this->shouldThrow('Happyr\DoctrineSpecification\Exception\NotConvertibleException')
-            ->during('transform', array($qb, 'a'));
+        $this->shouldThrow(NotConvertibleException::class)->during('transform', array($qb, 'a'));
     }
 }

--- a/tests/Operand/SubtractionSpec.php
+++ b/tests/Operand/SubtractionSpec.php
@@ -4,6 +4,7 @@ namespace tests\Happyr\DoctrineSpecification\Operand;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Operand\Operand;
 use Happyr\DoctrineSpecification\Operand\Subtraction;
 use Happyr\DoctrineSpecification\Operand\Field;
 use PhpSpec\ObjectBehavior;
@@ -24,12 +25,12 @@ class SubtractionSpec extends ObjectBehavior
 
     public function it_is_a_sub()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Subtraction');
+        $this->shouldBeAnInstanceOf(Subtraction::class);
     }
 
     public function it_is_a_operand()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Operand');
+        $this->shouldBeAnInstanceOf(Operand::class);
     }
 
     public function it_is_transformable(QueryBuilder $qb, ArrayCollection $parameters)

--- a/tests/Operand/ValueSpec.php
+++ b/tests/Operand/ValueSpec.php
@@ -5,6 +5,7 @@ namespace tests\Happyr\DoctrineSpecification\Operand;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Operand\Operand;
 use Happyr\DoctrineSpecification\Operand\Value;
 use PhpSpec\ObjectBehavior;
 
@@ -24,12 +25,12 @@ class ValueSpec extends ObjectBehavior
 
     public function it_is_a_value()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Value');
+        $this->shouldBeAnInstanceOf(Value::class);
     }
 
     public function it_is_a_operand()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Operand');
+        $this->shouldBeAnInstanceOf(Operand::class);
     }
 
     public function it_is_transformable(QueryBuilder $qb, ArrayCollection $parameters)

--- a/tests/Operand/ValuesSpec.php
+++ b/tests/Operand/ValuesSpec.php
@@ -5,6 +5,7 @@ namespace tests\Happyr\DoctrineSpecification\Operand;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Operand\Operand;
 use Happyr\DoctrineSpecification\Operand\Values;
 use PhpSpec\ObjectBehavior;
 
@@ -24,12 +25,12 @@ class ValuesSpec extends ObjectBehavior
 
     public function it_is_a_values()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Values');
+        $this->shouldBeAnInstanceOf(Values::class);
     }
 
     public function it_is_a_operand()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Operand');
+        $this->shouldBeAnInstanceOf(Operand::class);
     }
 
     public function it_is_transformable(QueryBuilder $qb, ArrayCollection $parameters)

--- a/tests/Query/AddSelectSpec.php
+++ b/tests/Query/AddSelectSpec.php
@@ -5,6 +5,7 @@ namespace tests\Happyr\DoctrineSpecification\Query;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Operand\Field;
 use Happyr\DoctrineSpecification\Query\AddSelect;
+use Happyr\DoctrineSpecification\Query\QueryModifier;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -19,12 +20,12 @@ class AddSelectSpec extends ObjectBehavior
 
     public function it_is_a_add_select()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Query\AddSelect');
+        $this->shouldBeAnInstanceOf(AddSelect::class);
     }
 
     public function it_is_a_specification()
     {
-        $this->shouldHaveType('Happyr\DoctrineSpecification\Query\QueryModifier');
+        $this->shouldHaveType(QueryModifier::class);
     }
 
     public function it_add_select_single_filed(QueryBuilder $qb)

--- a/tests/Query/InnerJoinSpec.php
+++ b/tests/Query/InnerJoinSpec.php
@@ -4,6 +4,7 @@ namespace tests\Happyr\DoctrineSpecification\Query;
 
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Query\InnerJoin;
+use Happyr\DoctrineSpecification\Query\QueryModifier;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -18,7 +19,7 @@ class InnerJoinSpec extends ObjectBehavior
 
     public function it_is_a_specification()
     {
-        $this->shouldHaveType('Happyr\DoctrineSpecification\Query\QueryModifier');
+        $this->shouldHaveType(QueryModifier::class);
     }
 
     public function it_joins_with_default_dql_alias(QueryBuilder $qb)

--- a/tests/Query/JoinSpec.php
+++ b/tests/Query/JoinSpec.php
@@ -4,6 +4,7 @@ namespace tests\Happyr\DoctrineSpecification\Query;
 
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Query\Join;
+use Happyr\DoctrineSpecification\Query\QueryModifier;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -18,7 +19,7 @@ class JoinSpec extends ObjectBehavior
 
     public function it_is_a_specification()
     {
-        $this->shouldHaveType('Happyr\DoctrineSpecification\Query\QueryModifier');
+        $this->shouldHaveType(QueryModifier::class);
     }
 
     public function it_joins_with_default_dql_alias(QueryBuilder $qb)

--- a/tests/Query/LeftJoinSpec.php
+++ b/tests/Query/LeftJoinSpec.php
@@ -4,6 +4,7 @@ namespace tests\Happyr\DoctrineSpecification\Query;
 
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Query\LeftJoin;
+use Happyr\DoctrineSpecification\Query\QueryModifier;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -18,7 +19,7 @@ class LeftJoinSpec extends ObjectBehavior
 
     public function it_is_a_specification()
     {
-        $this->shouldHaveType('Happyr\DoctrineSpecification\Query\QueryModifier');
+        $this->shouldHaveType(QueryModifier::class);
     }
 
     public function it_joins_with_default_dql_alias(QueryBuilder $qb)

--- a/tests/Query/SelectSpec.php
+++ b/tests/Query/SelectSpec.php
@@ -4,6 +4,7 @@ namespace tests\Happyr\DoctrineSpecification\Query;
 
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Operand\Field;
+use Happyr\DoctrineSpecification\Query\QueryModifier;
 use Happyr\DoctrineSpecification\Query\Select;
 use PhpSpec\ObjectBehavior;
 
@@ -19,12 +20,12 @@ class SelectSpec extends ObjectBehavior
 
     public function it_is_a_select()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Query\Select');
+        $this->shouldBeAnInstanceOf(Select::class);
     }
 
     public function it_is_a_specification()
     {
-        $this->shouldHaveType('Happyr\DoctrineSpecification\Query\QueryModifier');
+        $this->shouldHaveType(QueryModifier::class);
     }
 
     public function it_select_single_filed(QueryBuilder $qb)

--- a/tests/Query/Selection/ArgumentToSelectionConverterSpec.php
+++ b/tests/Query/Selection/ArgumentToSelectionConverterSpec.php
@@ -13,7 +13,7 @@ class ArgumentToSelectionConverterSpec extends ObjectBehavior
 {
     public function it_is_a_converter()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Query\Selection\ArgumentToSelectionConverter');
+        $this->shouldBeAnInstanceOf(ArgumentToSelectionConverter::class);
     }
 
     public function it_not_convert_field_to_selection(Field $field)
@@ -23,6 +23,6 @@ class ArgumentToSelectionConverterSpec extends ObjectBehavior
 
     public function it_convert_argument_to_field()
     {
-        $this->toSelection('foo')->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Operand\Field');
+        $this->toSelection('foo')->shouldBeAnInstanceOf(Field::class);
     }
 }

--- a/tests/Query/Selection/SelectAsSpec.php
+++ b/tests/Query/Selection/SelectAsSpec.php
@@ -8,6 +8,7 @@ use Happyr\DoctrineSpecification\Filter\Equals;
 use Happyr\DoctrineSpecification\Operand\Field;
 use Happyr\DoctrineSpecification\Operand\Value;
 use Happyr\DoctrineSpecification\Query\Selection\SelectAs;
+use Happyr\DoctrineSpecification\Query\Selection\Selection;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -26,12 +27,12 @@ class SelectAsSpec extends ObjectBehavior
 
     public function it_is_a_select_as()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Query\Selection\SelectAs');
+        $this->shouldBeAnInstanceOf(SelectAs::class);
     }
 
     public function it_is_a_selection()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Query\Selection\Selection');
+        $this->shouldBeAnInstanceOf(Selection::class);
     }
 
     public function it_is_transformable(QueryBuilder $qb)

--- a/tests/Query/Selection/SelectEntitySpec.php
+++ b/tests/Query/Selection/SelectEntitySpec.php
@@ -4,6 +4,7 @@ namespace tests\Happyr\DoctrineSpecification\Query\Selection;
 
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Query\Selection\SelectEntity;
+use Happyr\DoctrineSpecification\Query\Selection\Selection;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -20,12 +21,12 @@ class SelectEntitySpec extends ObjectBehavior
 
     public function it_is_a_select_entity()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Query\Selection\SelectEntity');
+        $this->shouldBeAnInstanceOf(SelectEntity::class);
     }
 
     public function it_is_a_selection()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Query\Selection\Selection');
+        $this->shouldBeAnInstanceOf(Selection::class);
     }
 
     public function it_is_transformable(QueryBuilder $qb)

--- a/tests/Query/Selection/SelectHiddenAsSpec.php
+++ b/tests/Query/Selection/SelectHiddenAsSpec.php
@@ -8,6 +8,7 @@ use Happyr\DoctrineSpecification\Filter\Equals;
 use Happyr\DoctrineSpecification\Operand\Field;
 use Happyr\DoctrineSpecification\Operand\Value;
 use Happyr\DoctrineSpecification\Query\Selection\SelectHiddenAs;
+use Happyr\DoctrineSpecification\Query\Selection\Selection;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -26,12 +27,12 @@ class SelectHiddenAsSpec extends ObjectBehavior
 
     public function it_is_a_select_as()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Query\Selection\SelectHiddenAs');
+        $this->shouldBeAnInstanceOf(SelectHiddenAs::class);
     }
 
     public function it_is_a_selection()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Query\Selection\Selection');
+        $this->shouldBeAnInstanceOf(Selection::class);
     }
 
     public function it_is_transformable(QueryBuilder $qb)

--- a/tests/Result/AsArraySpec.php
+++ b/tests/Result/AsArraySpec.php
@@ -5,6 +5,7 @@ namespace tests\Happyr\DoctrineSpecification\Result;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\Query;
 use Happyr\DoctrineSpecification\Result\AsArray;
+use Happyr\DoctrineSpecification\Result\ResultModifier;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -14,7 +15,7 @@ class AsArraySpec extends ObjectBehavior
 {
     public function it_is_a_result_modifier()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Result\ResultModifier');
+        $this->shouldBeAnInstanceOf(ResultModifier::class);
     }
 
     public function it_sets_hydration_mode_to_array(AbstractQuery $query)

--- a/tests/Result/AsSingleScalarSpec.php
+++ b/tests/Result/AsSingleScalarSpec.php
@@ -5,6 +5,7 @@ namespace tests\Happyr\DoctrineSpecification\Result;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\Query;
 use Happyr\DoctrineSpecification\Result\AsSingleScalar;
+use Happyr\DoctrineSpecification\Result\ResultModifier;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -14,7 +15,7 @@ class AsSingleScalarSpec extends ObjectBehavior
 {
     public function it_is_a_result_modifier()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Result\ResultModifier');
+        $this->shouldBeAnInstanceOf(ResultModifier::class);
     }
 
     public function it_sets_hydration_mode_to_object(AbstractQuery $query)

--- a/tests/Result/CacheSpec.php
+++ b/tests/Result/CacheSpec.php
@@ -4,6 +4,7 @@ namespace tests\Happyr\DoctrineSpecification\Result;
 
 use Doctrine\ORM\AbstractQuery;
 use Happyr\DoctrineSpecification\Result\Cache;
+use Happyr\DoctrineSpecification\Result\ResultModifier;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -20,7 +21,7 @@ class CacheSpec extends ObjectBehavior
 
     public function it_is_a_specification()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Result\ResultModifier');
+        $this->shouldBeAnInstanceOf(ResultModifier::class);
     }
 
     public function it_caches_query_for_given_time(AbstractQuery $query)

--- a/tests/Result/RoundDateTimeSpec.php
+++ b/tests/Result/RoundDateTimeSpec.php
@@ -21,7 +21,7 @@ class RoundDateTimeSpec
 
     public function it_is_a_specification()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Result\RoundDateTime');
+        $this->shouldBeAnInstanceOf(RoundDateTime::class);
     }
 
     public function it_round_date_time_in_query_parameters_for_given_time(

--- a/tests/SpecSpec.php
+++ b/tests/SpecSpec.php
@@ -2,6 +2,25 @@
 
 namespace tests\Happyr\DoctrineSpecification;
 
+use Happyr\DoctrineSpecification\Logic\LogicX;
+use Happyr\DoctrineSpecification\Operand\Addition;
+use Happyr\DoctrineSpecification\Operand\Alias;
+use Happyr\DoctrineSpecification\Operand\BitAnd;
+use Happyr\DoctrineSpecification\Operand\BitLeftShift;
+use Happyr\DoctrineSpecification\Operand\BitNot;
+use Happyr\DoctrineSpecification\Operand\BitOr;
+use Happyr\DoctrineSpecification\Operand\BitRightShift;
+use Happyr\DoctrineSpecification\Operand\BitXor;
+use Happyr\DoctrineSpecification\Operand\Division;
+use Happyr\DoctrineSpecification\Operand\Modulo;
+use Happyr\DoctrineSpecification\Operand\Multiplication;
+use Happyr\DoctrineSpecification\Operand\PlatformFunction;
+use Happyr\DoctrineSpecification\Operand\Subtraction;
+use Happyr\DoctrineSpecification\Query\AddSelect;
+use Happyr\DoctrineSpecification\Query\Select;
+use Happyr\DoctrineSpecification\Query\Selection\SelectAs;
+use Happyr\DoctrineSpecification\Query\Selection\SelectEntity;
+use Happyr\DoctrineSpecification\Query\Selection\SelectHiddenAs;
 use Happyr\DoctrineSpecification\Spec;
 use PhpSpec\ObjectBehavior;
 
@@ -12,101 +31,101 @@ class SpecSpec extends ObjectBehavior
 {
     public function it_creates_an_x_specification()
     {
-        $this->andX()->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Logic\LogicX');
+        $this->andX()->shouldReturnAnInstanceOf(LogicX::class);
     }
 
     public function it_creates_add_operand()
     {
-        $this->add('foo', 'bar')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Operand\Addition');
+        $this->add('foo', 'bar')->shouldReturnAnInstanceOf(Addition::class);
     }
 
     public function it_creates_sub_operand()
     {
-        $this->sub('foo', 'bar')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Operand\Subtraction');
+        $this->sub('foo', 'bar')->shouldReturnAnInstanceOf(Subtraction::class);
     }
 
     public function it_creates_mul_operand()
     {
-        $this->mul('foo', 'bar')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Operand\Multiplication');
+        $this->mul('foo', 'bar')->shouldReturnAnInstanceOf(Multiplication::class);
     }
 
     public function it_creates_div_operand()
     {
-        $this->div('foo', 'bar')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Operand\Division');
+        $this->div('foo', 'bar')->shouldReturnAnInstanceOf(Division::class);
     }
 
     public function it_creates_mod_operand()
     {
-        $this->mod('foo', 'bar')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Operand\Modulo');
+        $this->mod('foo', 'bar')->shouldReturnAnInstanceOf(Modulo::class);
     }
 
     public function it_create_bit_and_operand()
     {
-        $this->bAnd('foo', 'bar')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Operand\BitAnd');
+        $this->bAnd('foo', 'bar')->shouldReturnAnInstanceOf(BitAnd::class);
     }
 
     public function it_create_bit_or_operand()
     {
-        $this->bOr('foo', 'bar')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Operand\BitOr');
+        $this->bOr('foo', 'bar')->shouldReturnAnInstanceOf(BitOr::class);
     }
 
     public function it_create_bit_xor_operand()
     {
-        $this->bXor('foo', 'bar')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Operand\BitXor');
+        $this->bXor('foo', 'bar')->shouldReturnAnInstanceOf(BitXor::class);
     }
 
     public function it_create_bit_left_shift_operand()
     {
-        $this->bLs('foo', 'bar')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Operand\BitLeftShift');
+        $this->bLs('foo', 'bar')->shouldReturnAnInstanceOf(BitLeftShift::class);
     }
 
     public function it_create_bit_right_shift_operand()
     {
-        $this->bRs('foo', 'bar')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Operand\BitRightShift');
+        $this->bRs('foo', 'bar')->shouldReturnAnInstanceOf(BitRightShift::class);
     }
 
     public function it_create_bit_not_operand()
     {
-        $this->bNot('foo')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Operand\BitNot');
+        $this->bNot('foo')->shouldReturnAnInstanceOf(BitNot::class);
     }
 
     public function it_creates_an_function()
     {
-        $this->fun('UPPER', 'foo')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Operand\PlatformFunction');
+        $this->fun('UPPER', 'foo')->shouldReturnAnInstanceOf(PlatformFunction::class);
     }
 
     public function it_creates_an_magic_function()
     {
-        $this->__callStatic('UPPER', ['foo'])->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Operand\PlatformFunction');
+        $this->__callStatic('UPPER', ['foo'])->shouldReturnAnInstanceOf(PlatformFunction::class);
     }
 
     public function it_creates_select_query_modifier()
     {
-        $this->select('foo')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Query\Select');
+        $this->select('foo')->shouldReturnAnInstanceOf(Select::class);
     }
 
     public function it_creates_add_select_query_modifier()
     {
-        $this->addSelect('foo')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Query\AddSelect');
+        $this->addSelect('foo')->shouldReturnAnInstanceOf(AddSelect::class);
     }
 
     public function it_creates_select_entity_selection()
     {
-        $this->selectEntity('u')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Query\Selection\SelectEntity');
+        $this->selectEntity('u')->shouldReturnAnInstanceOf(SelectEntity::class);
     }
 
     public function it_creates_select_as_selection()
     {
-        $this->selectAs('foo', 'bar')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Query\Selection\SelectAs');
+        $this->selectAs('foo', 'bar')->shouldReturnAnInstanceOf(SelectAs::class);
     }
 
     public function it_creates_select_hidden_as_selection()
     {
-        $this->selectHiddenAs('foo', 'bar')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Query\Selection\SelectHiddenAs');
+        $this->selectHiddenAs('foo', 'bar')->shouldReturnAnInstanceOf(SelectHiddenAs::class);
     }
 
     public function it_creates_alias_operand()
     {
-        $this->alias('foo')->shouldReturnAnInstanceOf('Happyr\DoctrineSpecification\Operand\Alias');
+        $this->alias('foo')->shouldReturnAnInstanceOf(Alias::class);
     }
 }

--- a/tests/Specification/CountOfSpec.php
+++ b/tests/Specification/CountOfSpec.php
@@ -7,6 +7,7 @@ use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Filter\Equals;
 use Happyr\DoctrineSpecification\Query\GroupBy;
 use Happyr\DoctrineSpecification\Specification\CountOf;
+use Happyr\DoctrineSpecification\Specification\Specification;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -21,12 +22,12 @@ class CountOfSpec extends ObjectBehavior
 
     public function it_is_a_CountOf()
     {
-        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Specification\CountOf');
+        $this->shouldBeAnInstanceOf(CountOf::class);
     }
 
     public function it_is_a_specification()
     {
-        $this->shouldHaveType('Happyr\DoctrineSpecification\Specification\Specification');
+        $this->shouldHaveType(Specification::class);
     }
 
     public function it_count_of_all(QueryBuilder $qb)


### PR DESCRIPTION
Using class names in strings makes refactoring difficult. This is an outdated approach.
https://php.net/manual/en/language.oop5.constants.php