### PR TITLE
Make DQL alias optional

### DIFF
--- a/src/Query/GroupBy.php
+++ b/src/Query/GroupBy.php
@@ -17,8 +17,8 @@ class GroupBy implements QueryModifier
     protected $dqlAlias;
 
     /**
-     * @param string $field
-     * @param string $dqlAlias
+     * @param string           $field
+     * @param string|bool|null $dqlAlias
      */
     public function __construct($field, $dqlAlias = null)
     {
@@ -32,9 +32,14 @@ class GroupBy implements QueryModifier
      */
     public function modify(QueryBuilder $qb, $dqlAlias)
     {
-        if (null !== $this->dqlAlias) {
-            $dqlAlias = $this->dqlAlias;
+        if (false === $this->dqlAlias) {
+            $qb->addGroupBy(sprintf('%s', $this->field));
+        } else {
+            if (null !== $this->dqlAlias) {
+                $dqlAlias = $this->dqlAlias;
+            }
+
+            $qb->addGroupBy(sprintf('%s.%s', $dqlAlias, $this->field));
         }
-        $qb->addGroupBy(sprintf('%s.%s', $dqlAlias, $this->field));
     }
 }

--- a/src/Query/OrderBy.php
+++ b/src/Query/OrderBy.php
@@ -22,9 +22,9 @@ class OrderBy implements QueryModifier
     protected $dqlAlias;
 
     /**
-     * @param string      $field
-     * @param string      $order
-     * @param string|null $dqlAlias
+     * @param string           $field
+     * @param string           $order
+     * @param string|bool|null $dqlAlias
      */
     public function __construct($field, $order = 'ASC', $dqlAlias = null)
     {
@@ -39,10 +39,14 @@ class OrderBy implements QueryModifier
      */
     public function modify(QueryBuilder $qb, $dqlAlias)
     {
-        if (null !== $this->dqlAlias) {
-            $dqlAlias = $this->dqlAlias;
-        }
+        if (false === $this->dqlAlias) {
+            $qb->addOrderBy(sprintf('%s', $this->field), $this->order);
+        } else {
+            if (null !== $this->dqlAlias) {
+                $dqlAlias = $this->dqlAlias;
+            }
 
-        $qb->addOrderBy(sprintf('%s.%s', $dqlAlias, $this->field), $this->order);
+            $qb->addOrderBy(sprintf('%s.%s', $dqlAlias, $this->field), $this->order);
+        }
     }
 }


### PR DESCRIPTION
Sometimes we need to orderBy or groupBy on aliases that are defined in the SELECT statement.

Use case:

```sql
SELECT
DATE_FORMAT(pubTime), "%Y-%U") AS formattedDate,
MIN(pubTime) AS minDate,
MAX(pubTime) AS maxDate
FROM table
GROUP BY asFormattedDate
ORDER BY maxDate DESC;
```

With Doctrine QueryBuilder, this works like a charm:

```php
$queryBuilder
    ->select('DATE_FORMAT(pubTime), \'%Y-%U\') AS formattedDate')
    ->addSelect('MIN(pubTime) AS minDate')
    ->addSelect('MAX(pubTime) AS maxDate')
    ->groupBy('formattedDate')
    ->orderBy('maxDate', 'DESC);
```

However, Doctrine-Specification library always puts the entity alias in front of the column name.

```php
$spec = Spec::andX(
    Spec::groupBy('formattedDate'),
    Spec::orderBy('maxDate', 'DESC)
);

$queryBuilder = $em->getRepository('table')->getQueryBuilder($spec)
    ->select('DATE_FORMAT(pubTime), \'%Y-%U\') AS formattedDate')
    ->addSelect('MIN(pubTime) AS minDate')
    ->addSelect('MAX(pubTime) AS maxDate');
```

Which produces: `GROUP BY e.formattedDate, ORDER BY e.maxDate DESC`. In this case, the DQL alias must be removed.