### PR TITLE
Support for indexing results by arbitrary field

### DIFF
--- a/src/Query/IndexBy.php
+++ b/src/Query/IndexBy.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Happyr\DoctrineSpecification\Query;
+
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * Class IndexBy.
+ */
+class IndexBy implements QueryModifier
+{
+    /**
+     * Field name.
+     *
+     * @var string
+     */
+    private $field;
+
+    /**
+     * DQL Alias.
+     *
+     * @var string
+     */
+    private $dqlAlias;
+
+    /**
+     * IndexBy constructor.
+     *
+     * @param string $field    Field name for indexing
+     * @param string $dqlAlias DQL alias of field
+     */
+    public function __construct($field, $dqlAlias = null)
+    {
+        $this->field = $field;
+        $this->dqlAlias = $dqlAlias;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function modify(QueryBuilder $qb, $dqlAlias)
+    {
+        if (null !== $this->dqlAlias) {
+            $dqlAlias = $this->dqlAlias;
+        }
+
+        $qb->indexBy($dqlAlias, sprintf('%s.%s', $dqlAlias, $this->field));
+    }
+}

--- a/src/Spec.php
+++ b/src/Spec.php
@@ -33,6 +33,7 @@ use Happyr\DoctrineSpecification\Operand\Value;
 use Happyr\DoctrineSpecification\Operand\Values;
 use Happyr\DoctrineSpecification\Query\AddSelect;
 use Happyr\DoctrineSpecification\Query\GroupBy;
+use Happyr\DoctrineSpecification\Query\IndexBy;
 use Happyr\DoctrineSpecification\Query\InnerJoin;
 use Happyr\DoctrineSpecification\Query\Join;
 use Happyr\DoctrineSpecification\Query\LeftJoin;
@@ -177,6 +178,17 @@ class Spec
     public static function innerJoin($field, $newAlias, $dqlAlias = null)
     {
         return new InnerJoin($field, $newAlias, $dqlAlias);
+    }
+
+    /**
+     * @param string $field
+     * @param string $dqlAlias
+     *
+     * @return IndexBy
+     */
+    public static function indexBy($field, $dqlAlias = null)
+    {
+        return new IndexBy($field, $dqlAlias);
     }
 
     /**

--- a/tests/Query/IndexBySpec.php
+++ b/tests/Query/IndexBySpec.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace tests\Happyr\DoctrineSpecification\Query;
+
+use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Query\IndexBy;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @mixin IndexBy
+ */
+class IndexBySpec extends ObjectBehavior
+{
+    private $field = 'the_field';
+
+    private $alias = 'f';
+
+    public function let()
+    {
+        $this->beConstructedWith($this->field, $this->alias);
+    }
+
+    public function it_is_a_result_modifier()
+    {
+        $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Query\QueryModifier');
+    }
+
+    public function it_indexes_with_default_dql_alias(QueryBuilder $qb)
+    {
+        $this->beConstructedWith('something', 'x');
+        $qb->indexBy('x', 'x.something')->shouldBeCalled();
+        $this->modify($qb, 'a');
+    }
+
+    public function it_uses_local_alias_if_global_was_not_set(QueryBuilder $qb)
+    {
+        $this->beConstructedWith('thing');
+        $qb->indexBy('b', 'b.thing')->shouldBeCalled();
+        $this->modify($qb, 'b');
+    }
+}


### PR DESCRIPTION
This PR provides support for indexing resultsets by a given field.
```php
Spec::andX(
  Speс::indexBy('thing');
);
```