### PR TITLE
Having spec return NULL as filter

### DIFF
--- a/src/Specification/Having.php
+++ b/src/Specification/Having.php
@@ -33,6 +33,12 @@ class Having implements Specification
         if ($this->child instanceof QueryModifier) {
             $this->child->modify($qb, $dqlAlias);
         }
+
+        if ($this->child instanceof Filter) {
+            $qb->having($this->child->getFilter($qb, $dqlAlias));
+        } else {
+            $qb->having($this->child);
+        }
     }
 
     /**
@@ -43,12 +49,6 @@ class Having implements Specification
      */
     public function getFilter(QueryBuilder $qb, $dqlAlias)
     {
-        if ($this->child instanceof Filter) {
-            $qb->having($this->child->getFilter($qb, $dqlAlias));
-        } else {
-            $qb->having($this->child);
-        }
-
-        return '';
+        return;
     }
 }


### PR DESCRIPTION
This code

```php
$spec = Spec::andX(
    Spec::gte('day', $this->start),
    Spec::having(Spec::gt('views', 0)),
);
```

generate DQL

```
SELECT e FROM Entity e WHERE e.day >= :comparison_0 AND HAVING e.views > :comparison_1
```

and throw error

> [Syntax Error] line 0, col 148: Error: Expected Literal, got 'HAVING'

Spec `AndX` call [`Expr::andX()`](https://github.com/Happyr/Doctrine-Specification/blob/master/src/Logic/LogicX.php#L56) which create [`Doctrine\ORM\Query\Expr\Andx`](https://github.com/doctrine/orm/blob/master/lib/Doctrine/ORM/Query/Expr.php#L38) which extends [`Doctrine\ORM\Query\Expr\Composite`](https://github.com/doctrine/orm/blob/master/lib/Doctrine/ORM/Query/Expr/Base.php#L40) which extends [`Doctrine\ORM\Query\Expr\Base`](https://github.com/doctrine/orm/blob/master/lib/Doctrine/ORM/Query/Expr/Composite.php#L14).
In `Base::__construct()` called [`Base::addMultiple()`](https://github.com/doctrine/orm/blob/master/lib/Doctrine/ORM/Query/Expr/Base.php#L40) called [`Base::add()`](https://github.com/doctrine/orm/blob/master/lib/Doctrine/ORM/Query/Expr/Base.php#L51).
The filter result is a argument here and if the filter result is `NULL`, than it will be [ignored](https://github.com/doctrine/orm/blob/master/lib/Doctrine/ORM/Query/Expr/Base.php#L66). If the filter return a empty string, then this string will be added to query.

I made this mistake in PR #194.

The problem is that `Having` is not a specification it is a `QueryModifier` and it cannot return anything as a filter.