### PR TITLE
Add Distinct query modifier and CountDistinct operand

### DIFF
--- a/src/Operand/CountDistinct.php
+++ b/src/Operand/CountDistinct.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Happyr\DoctrineSpecification\Operand;
+
+use Doctrine\ORM\QueryBuilder;
+
+class CountDistinct implements Operand
+{
+    /**
+     * @var Operand|string
+     */
+    private $field;
+
+    /**
+     * @param Operand|string $field
+     */
+    public function __construct($field)
+    {
+        $this->field = $field;
+    }
+
+    /**
+     * @param QueryBuilder $qb
+     * @param string       $dqlAlias
+     *
+     * @return string
+     */
+    public function transform(QueryBuilder $qb, $dqlAlias)
+    {
+        $field = ArgumentToOperandConverter::toField($this->field);
+        $field = $field->transform($qb, $dqlAlias);
+
+        return sprintf('COUNT(DISTINCT %s)', $field);
+    }
+}

--- a/src/Query/Distinct.php
+++ b/src/Query/Distinct.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Happyr\DoctrineSpecification\Query;
+
+use Doctrine\ORM\QueryBuilder;
+
+class Distinct implements QueryModifier
+{
+    /**
+     * @param QueryBuilder $qb
+     * @param string       $dqlAlias
+     */
+    public function modify(QueryBuilder $qb, $dqlAlias)
+    {
+        $qb->distinct();
+    }
+}

--- a/src/Spec.php
+++ b/src/Spec.php
@@ -32,6 +32,7 @@ use Happyr\DoctrineSpecification\Operand\PlatformFunction;
 use Happyr\DoctrineSpecification\Operand\Value;
 use Happyr\DoctrineSpecification\Operand\Values;
 use Happyr\DoctrineSpecification\Query\AddSelect;
+use Happyr\DoctrineSpecification\Query\Distinct;
 use Happyr\DoctrineSpecification\Query\GroupBy;
 use Happyr\DoctrineSpecification\Query\IndexBy;
 use Happyr\DoctrineSpecification\Query\InnerJoin;
@@ -243,6 +244,14 @@ class Spec
     public static function groupBy($field, $dqlAlias = null)
     {
         return new GroupBy($field, $dqlAlias);
+    }
+
+    /**
+     * @return Distinct
+     */
+    public static function distinct()
+    {
+        return new Distinct();
     }
 
     /*

--- a/src/Spec.php
+++ b/src/Spec.php
@@ -21,6 +21,7 @@ use Happyr\DoctrineSpecification\Operand\BitNot;
 use Happyr\DoctrineSpecification\Operand\BitOr;
 use Happyr\DoctrineSpecification\Operand\BitRightShift;
 use Happyr\DoctrineSpecification\Operand\BitXor;
+use Happyr\DoctrineSpecification\Operand\CountDistinct;
 use Happyr\DoctrineSpecification\Operand\Division;
 use Happyr\DoctrineSpecification\Operand\Field;
 use Happyr\DoctrineSpecification\Operand\LikePattern;
@@ -588,6 +589,16 @@ class Spec
     public static function likePattern($value, $format = LikePattern::CONTAINS)
     {
         return new LikePattern($value, $format);
+    }
+
+    /**
+     * @param Operand|string $field
+     *
+     * @return CountDistinct
+     */
+    public static function countDistinct($field)
+    {
+        return new CountDistinct($field);
     }
 
     /*

--- a/tests/Operand/CountDistinctSpec.php
+++ b/tests/Operand/CountDistinctSpec.php
@@ -2,7 +2,6 @@
 
 namespace tests\Happyr\DoctrineSpecification\Operand;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Operand\CountDistinct;
 use Happyr\DoctrineSpecification\Operand\Operand;

--- a/tests/Operand/CountDistinctSpec.php
+++ b/tests/Operand/CountDistinctSpec.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace tests\Happyr\DoctrineSpecification\Operand;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Operand\CountDistinct;
+use Happyr\DoctrineSpecification\Operand\Operand;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @mixin CountDistinct
+ */
+class CountDistinctSpec extends ObjectBehavior
+{
+    private $field = 'foo';
+
+    public function let()
+    {
+        $this->beConstructedWith($this->field);
+    }
+
+    public function it_is_a_count_distinct()
+    {
+        $this->shouldBeAnInstanceOf(CountDistinct::class);
+    }
+
+    public function it_is_a_operand()
+    {
+        $this->shouldBeAnInstanceOf(Operand::class);
+    }
+
+    public function it_is_transformable(QueryBuilder $qb)
+    {
+        $this->transform($qb, 'a')->shouldReturn('COUNT(DISTINCT a.foo)');
+    }
+}

--- a/tests/Query/DistinctSpec.php
+++ b/tests/Query/DistinctSpec.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace tests\Happyr\DoctrineSpecification\Query;
+
+use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Filter\Filter;
+use Happyr\DoctrineSpecification\Query\Distinct;
+use Happyr\DoctrineSpecification\Query\Having;
+use Happyr\DoctrineSpecification\Query\QueryModifier;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @mixin Distinct
+ */
+class DistinctSpec extends ObjectBehavior
+{
+    public function it_is_a_distinct()
+    {
+        $this->shouldBeAnInstanceOf(Distinct::class);
+    }
+
+    public function it_is_a_query_modifier()
+    {
+        $this->shouldHaveType(QueryModifier::class);
+    }
+
+    public function it_add_having(QueryBuilder $qb)
+    {
+        $qb->distinct()->shouldBeCalled();
+        $this->modify($qb, 'a');
+    }
+}

--- a/tests/Query/DistinctSpec.php
+++ b/tests/Query/DistinctSpec.php
@@ -3,9 +3,7 @@
 namespace tests\Happyr\DoctrineSpecification\Query;
 
 use Doctrine\ORM\QueryBuilder;
-use Happyr\DoctrineSpecification\Filter\Filter;
 use Happyr\DoctrineSpecification\Query\Distinct;
-use Happyr\DoctrineSpecification\Query\Having;
 use Happyr\DoctrineSpecification\Query\QueryModifier;
 use PhpSpec\ObjectBehavior;
 

--- a/tests/SpecSpec.php
+++ b/tests/SpecSpec.php
@@ -8,6 +8,7 @@ use Happyr\DoctrineSpecification\Operand\Addition;
 use Happyr\DoctrineSpecification\Operand\Alias;
 use Happyr\DoctrineSpecification\Operand\BitAnd;
 use Happyr\DoctrineSpecification\Operand\BitOr;
+use Happyr\DoctrineSpecification\Operand\CountDistinct;
 use Happyr\DoctrineSpecification\Operand\Division;
 use Happyr\DoctrineSpecification\Operand\Modulo;
 use Happyr\DoctrineSpecification\Operand\Multiplication;
@@ -35,6 +36,11 @@ class SpecSpec extends ObjectBehavior
     public function it_creates_distinct()
     {
         $this->distinct()->shouldReturnAnInstanceOf(Distinct::class);
+    }
+
+    public function it_creates_count_distinct()
+    {
+        $this->countDistinct('foo')->shouldReturnAnInstanceOf(CountDistinct::class);
     }
 
     public function it_creates_add_operand()

--- a/tests/SpecSpec.php
+++ b/tests/SpecSpec.php
@@ -14,6 +14,7 @@ use Happyr\DoctrineSpecification\Operand\Multiplication;
 use Happyr\DoctrineSpecification\Operand\PlatformFunction;
 use Happyr\DoctrineSpecification\Operand\Subtraction;
 use Happyr\DoctrineSpecification\Query\AddSelect;
+use Happyr\DoctrineSpecification\Query\Distinct;
 use Happyr\DoctrineSpecification\Query\Select;
 use Happyr\DoctrineSpecification\Query\Selection\SelectAs;
 use Happyr\DoctrineSpecification\Query\Selection\SelectEntity;
@@ -29,6 +30,11 @@ class SpecSpec extends ObjectBehavior
     public function it_creates_an_x_specification()
     {
         $this->andX()->shouldReturnAnInstanceOf(LogicX::class);
+    }
+
+    public function it_creates_distinct()
+    {
+        $this->distinct()->shouldReturnAnInstanceOf(Distinct::class);
     }
 
     public function it_creates_add_operand()


### PR DESCRIPTION
Add new fieature for use `DISTINCT` in queries.

## Distinct query modifier

```php
$rep->match(Spec::andX(
    Spec::distinct(),
    Spec::select('id'),
    Spec::innerJoin('events', 'ev'),
    Spec::eq('discount', true, 'ev')
));
```

DQL

```
SELECT DISTINCT e.id FROM Action e INNER JOIN e.events ev WHERE ev.discount = TRUE
```

## CountDistinct operand


```php
$rep->match(Spec::andX(
    Spec::select(Spec::selectAs(Spec::countDistinct('id'), 'total')),
    Spec::innerJoin('events', 'ev'),
    Spec::eq('discount', true, 'ev')
));
```

DQL

```
SELECT COUNT(DISTINCT e.id) total FROM Action e INNER JOIN e.events ev WHERE ev.discount = TRUE
```