### PR TITLE
Call to an undefined method DateTimeInterface::setTimestamp().

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,4 +1,4 @@
 parameters:
-    level: 1
+    level: 2
     paths:
         - src

--- a/src/Result/RoundDateTime.php
+++ b/src/Result/RoundDateTime.php
@@ -29,10 +29,12 @@ class RoundDateTime implements ResultModifier
     public function modify(AbstractQuery $query)
     {
         foreach ($query->getParameters() as $parameter) {
-            /* @var $parameter Parameter */
-            if ($parameter->getValue() instanceof \DateTimeInterface) {
+            if ($parameter instanceof Parameter &&
+                ($value = $parameter->getValue()) &&
+                $value instanceof \DateTimeInterface
+            ) {
                 // round down so that the results do not include data that should not be there.
-                $date = clone $parameter->getValue();
+                $date = new \DateTimeImmutable('now', $value->getTimezone());
                 $date = $date->setTimestamp(floor($date->getTimestamp() / $this->roundSeconds) * $this->roundSeconds);
 
                 $query->setParameter($parameter->getName(), $date, $parameter->getType());


### PR DESCRIPTION
Fix error detected by PHPStan and level up to `2`.

* Call to an undefined method `DateTimeInterface::setTimestamp()`.