### PR TITLE
Fix PHPStan errors for level 3

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,4 +1,4 @@
 parameters:
-    level: 2
+    level: 3
     paths:
         - src

--- a/src/BaseSpecification.php
+++ b/src/BaseSpecification.php
@@ -38,7 +38,7 @@ abstract class BaseSpecification implements Specification
             return $spec->getFilter($qb, $this->getAlias($dqlAlias));
         }
 
-        return;
+        return '';
     }
 
     /**
@@ -56,11 +56,11 @@ abstract class BaseSpecification implements Specification
     /**
      * Return all the specifications.
      *
-     * @return Filter|QueryModifier
+     * @return Filter|QueryModifier|null
      */
     protected function getSpec()
     {
-        return;
+        return null;
     }
 
     /**

--- a/src/EntitySpecificationRepositoryInterface.php
+++ b/src/EntitySpecificationRepositoryInterface.php
@@ -98,7 +98,7 @@ interface EntitySpecificationRepositoryInterface
      * @param Filter|QueryModifier $specification
      * @param ResultModifier|null  $modifier
      *
-     * @return mixed[]
+     * @return \Traversable
      */
     public function iterate($specification, ResultModifier $modifier = null);
 }

--- a/src/EntitySpecificationRepositoryTrait.php
+++ b/src/EntitySpecificationRepositoryTrait.php
@@ -157,7 +157,7 @@ trait EntitySpecificationRepositoryTrait
      * @param Filter|QueryModifier $specification
      * @param ResultModifier|null  $modifier
      *
-     * @return mixed[]|\Generator
+     * @return \Traversable
      */
     public function iterate($specification, ResultModifier $modifier = null)
     {

--- a/src/EntitySpecificationRepositoryTrait.php
+++ b/src/EntitySpecificationRepositoryTrait.php
@@ -74,7 +74,7 @@ trait EntitySpecificationRepositoryTrait
         try {
             return $this->matchSingleResult($specification, $modifier);
         } catch (Exception\NoResultException $e) {
-            return;
+            return null;
         }
     }
 
@@ -213,7 +213,7 @@ trait EntitySpecificationRepositoryTrait
         }
 
         if ($specification instanceof Filter
-            && $filter = (string) $specification->getFilter($queryBuilder, $alias ?: $this->getAlias())
+            && $filter = $specification->getFilter($queryBuilder, $alias ?: $this->getAlias())
         ) {
             $queryBuilder->andWhere($filter);
         }

--- a/src/Logic/LogicX.php
+++ b/src/Logic/LogicX.php
@@ -48,8 +48,8 @@ class LogicX implements Specification
     {
         $children = [];
         foreach ($this->children as $spec) {
-            if ($spec instanceof Filter) {
-                $children[] = $spec->getFilter($qb, $dqlAlias);
+            if ($spec instanceof Filter && $filter = $spec->getFilter($qb, $dqlAlias)) {
+                $children[] = $filter;
             }
         }
 

--- a/src/Spec.php
+++ b/src/Spec.php
@@ -115,10 +115,16 @@ class Spec
      */
     public static function andX()
     {
-        $args = func_get_args();
-        $reflection = new \ReflectionClass(AndX::class);
+        $spec = (new \ReflectionClass(AndX::class))->newInstanceArgs(func_get_args());
 
-        return $reflection->newInstanceArgs($args);
+        // hook for PHPStan
+        if (!($spec instanceof AndX)) {
+            throw new \RuntimeException(
+                sprintf('The specification must be an instance of "%s", but got "%s".', AndX::class, get_class($spec))
+            );
+        }
+
+        return $spec;
     }
 
     /**
@@ -126,10 +132,16 @@ class Spec
      */
     public static function orX()
     {
-        $args = func_get_args();
-        $reflection = new \ReflectionClass(OrX::class);
+        $spec = (new \ReflectionClass(OrX::class))->newInstanceArgs(func_get_args());
 
-        return $reflection->newInstanceArgs($args);
+        // hook for PHPStan
+        if (!($spec instanceof OrX)) {
+            throw new \RuntimeException(
+                sprintf('The specification must be an instance of "%s", but got "%s".', OrX::class, get_class($spec))
+            );
+        }
+
+        return $spec;
     }
 
     /**

--- a/src/Specification/Having.php
+++ b/src/Specification/Having.php
@@ -49,6 +49,6 @@ class Having implements Specification
      */
     public function getFilter(QueryBuilder $qb, $dqlAlias)
     {
-        return;
+        return '';
     }
 }


### PR DESCRIPTION
|  Line   |BaseSpecification.php
| ------ |-------------------------------------------------------------------------------------------------------------------------------
|  41     |Method Happyr\DoctrineSpecification\BaseSpecification::getFilter() should return string but empty return statement found.
|  63     |Method Happyr\DoctrineSpecification\BaseSpecification::getSpec() should return
|         |Happyr\DoctrineSpecification\Filter\Filter|Happyr\DoctrineSpecification\Query\QueryModifier but empty return statement found.

|  Line   |Spec.php
| ------ |----------------------------------------------------------------------------------------------------------------------------
|  121    |Method Happyr\DoctrineSpecification\Spec::andX() should return Happyr\DoctrineSpecification\Logic\AndX but returns object.
|  132    |Method Happyr\DoctrineSpecification\Spec::orX() should return Happyr\DoctrineSpecification\Logic\OrX but returns object.

|  Line   |Specification/Having.php
| ------ |------------------------------------------------------------------------------------------------------------------------------
|  52     |Method Happyr\DoctrineSpecification\Specification\Having::getFilter() should return string but empty return statement found.

| Line   |EntitySpecificationRepositoryTrait.php (in context of class Happyr\DoctrineSpecification\EntitySpecificationRepository)  
| ------ |------------------------------------------------------------------------------------------------------------------------- 
|  162    |Return type (Generator&iterable) of method  Happyr\DoctrineSpecification\EntitySpecificationRepository::iterate() should be compatible with return type (array) of method Happyr\DoctrineSpecification\EntitySpecificationRepositoryInterface::iterate()
