### PR TITLE
Fix PHPStan errors for level 5

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,4 +1,4 @@
 parameters:
-    level: 3
+    level: 5
     paths:
         - src

--- a/src/EntitySpecificationRepositoryTrait.php
+++ b/src/EntitySpecificationRepositoryTrait.php
@@ -187,9 +187,9 @@ trait EntitySpecificationRepositoryTrait
     }
 
     /**
-     * @param QueryBuilder         $queryBuilder
-     * @param Filter|QueryModifier $specification
-     * @param string               $alias
+     * @param QueryBuilder                    $queryBuilder
+     * @param Filter|QueryModifier|null|mixed $specification
+     * @param string                          $alias
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Result/RoundDateTime.php
+++ b/src/Result/RoundDateTime.php
@@ -34,8 +34,8 @@ class RoundDateTime implements ResultModifier
                 $value instanceof \DateTimeInterface
             ) {
                 // round down so that the results do not include data that should not be there.
-                $date = new \DateTimeImmutable('now', $value->getTimezone());
-                $date = $date->setTimestamp(floor($date->getTimestamp() / $this->roundSeconds) * $this->roundSeconds);
+                $uts = (int) (floor($value->getTimestamp() / $this->roundSeconds) * $this->roundSeconds);
+                $date = (new \DateTimeImmutable('now', $value->getTimezone()))->setTimestamp($uts);
 
                 $query->setParameter($parameter->getName(), $date, $parameter->getType());
             }


### PR DESCRIPTION
|  Line   |Result/RoundDateTime.php
| ------ |---------------------------------------------------------------------------------------------------
|  38     |Parameter # 1 `$unixtimestamp` of method `DateTimeImmutable::setTimestamp()` expects int, float given.


| Line   |EntitySpecificationRepositoryTrait.php (in context of class Happyr\DoctrineSpecification\EntitySpecificationRepository)  
| ------ |------------------------------------------------------------------------------------------------------------------------- 
|  202    |Result of && is always false.                                                                                            
|  207    |Else branch is unreachable because ternary operator condition is always                                                   true.  

https://github.com/phpstan/phpstan/issues/2538