### PR TITLE
Fix PHPStan errors for level 6

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,4 +1,4 @@
 parameters:
-    level: 5
+    level: 6
     paths:
         - src

--- a/src/Logic/LogicX.php
+++ b/src/Logic/LogicX.php
@@ -53,7 +53,15 @@ class LogicX implements Specification
             }
         }
 
-        return call_user_func_array(array($qb->expr(), $this->expression), $children);
+        $expression = [$qb->expr(), $this->expression];
+
+        if (!is_callable($expression)) {
+            throw new \InvalidArgumentException(
+                sprintf('Undefined "%s" method in "%s" class.', $this->expression, get_class($qb->expr()))
+            );
+        }
+
+        return call_user_func_array($expression, $children);
     }
 
     /**

--- a/src/Operand/ArgumentToOperandConverter.php
+++ b/src/Operand/ArgumentToOperandConverter.php
@@ -88,13 +88,15 @@ class ArgumentToOperandConverter
             return [$field, $value];
         }
 
-        if (!self::isAllOperands($arguments)) {
-            throw new NotConvertibleException('You passed arguments not all of which are operands.');
+        $result = [$field];
+        foreach ($arguments as $argument) {
+            if (!($argument instanceof Operand)) {
+                throw new NotConvertibleException('You passed arguments not all of which are operands.');
+            }
+            $result[] = $argument;
         }
+        $result[] = $value;
 
-        array_unshift($arguments, $field);
-        array_push($arguments, $value);
-
-        return $arguments;
+        return $result;
     }
 }

--- a/src/Operand/PlatformFunction.php
+++ b/src/Operand/PlatformFunction.php
@@ -88,8 +88,8 @@ class PlatformFunction implements Operand
             throw new InvalidArgumentException(sprintf('"%s" is not a valid function name.', $this->functionName));
         }
 
-        $arguments = ArgumentToOperandConverter::convert($this->arguments);
-        foreach ($arguments as $key => $argument) {
+        $arguments = [];
+        foreach (ArgumentToOperandConverter::convert($this->arguments) as $key => $argument) {
             $arguments[$key] = $argument->transform($qb, $dqlAlias);
         }
 


### PR DESCRIPTION
|  Line   |Logic/LogicX.php
| ------ |----------------------------------------------------------------------------------------------------------------------------------
|  56     |Parameter # 1 `$function` of function `call_user_func_array` expects `callable()`: `mixed`, `array(Doctrine\ORM\Query\Expr, string)` given.

|  Line   |Operand/ArgumentToOperandConverter.php                                                                                                              
| ------ |-----------------------------------------------------------------------------------------------------------------------------------------------------
|  98     |Method `Happyr\DoctrineSpecification\Operand\ArgumentToOperandConverter::convert()` should return `array<Happyr\DoctrineSpecification\Operand\Operand>` but returns `array<Happyr\DoctrineSpecification\Operand\Operand\|string>`.

|  Line   |Operand/PlatformFunction.php
| ------ |----------------------------------------------------------------------------------------
|  93     |Cannot call method `transform()` on `Happyr\DoctrineSpecification\Operand\Operand\|string`.
