### PR TITLE
Fix PHPStan errors for level 7

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,4 +1,4 @@
 parameters:
-    level: 6
+    level: 7
     paths:
         - src

--- a/src/BaseSpecification.php
+++ b/src/BaseSpecification.php
@@ -13,12 +13,12 @@ use Happyr\DoctrineSpecification\Specification\Specification;
 abstract class BaseSpecification implements Specification
 {
     /**
-     * @var string|null dqlAlias
+     * @var string|null
      */
-    private $dqlAlias = null;
+    private $dqlAlias;
 
     /**
-     * @param string $dqlAlias
+     * @param string|null $dqlAlias
      */
     public function __construct($dqlAlias = null)
     {

--- a/src/DBALTypesResolver.php
+++ b/src/DBALTypesResolver.php
@@ -37,10 +37,10 @@ final class DBALTypesResolver
         }
 
         // use class name as type name
-        $classNameParts = explode('\\', $className);
+        $classNameParts = explode('\\', str_replace('_', '\\', $className));
         $typeName = array_pop($classNameParts);
 
-        if (array_key_exists($typeName, Type::getTypesMap())) {
+        if ($typeName !== null && array_key_exists($typeName, Type::getTypesMap())) {
             return Type::getType($typeName);
         }
 

--- a/src/DBALTypesResolver.php
+++ b/src/DBALTypesResolver.php
@@ -40,7 +40,7 @@ final class DBALTypesResolver
         $classNameParts = explode('\\', str_replace('_', '\\', $className));
         $typeName = array_pop($classNameParts);
 
-        if ($typeName !== null && array_key_exists($typeName, Type::getTypesMap())) {
+        if (null !== $typeName && array_key_exists($typeName, Type::getTypesMap())) {
             return Type::getType($typeName);
         }
 

--- a/src/Filter/Comparison.php
+++ b/src/Filter/Comparison.php
@@ -38,7 +38,7 @@ class Comparison implements Filter
     protected $value;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $dqlAlias;
 

--- a/src/Filter/Comparison.php
+++ b/src/Filter/Comparison.php
@@ -68,7 +68,7 @@ class Comparison implements Filter
      */
     public function __construct($operator, $field, $value, $dqlAlias = null)
     {
-        if (!in_array($operator, self::$operators)) {
+        if (!in_array($operator, self::$operators, true)) {
             throw new InvalidArgumentException(sprintf(
                 '"%s" is not a valid comparison operator. Valid operators are: "%s"',
                 $operator,

--- a/src/Filter/In.php
+++ b/src/Filter/In.php
@@ -19,7 +19,7 @@ class In implements Filter
     protected $value;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $dqlAlias;
 

--- a/src/Filter/InstanceOfX.php
+++ b/src/Filter/InstanceOfX.php
@@ -22,8 +22,8 @@ class InstanceOfX implements Filter
      */
     public function __construct($value, $dqlAlias = null)
     {
-        $this->dqlAlias = $dqlAlias;
         $this->value = $value;
+        $this->dqlAlias = $dqlAlias;
     }
 
     /**

--- a/src/Filter/Like.php
+++ b/src/Filter/Like.php
@@ -27,7 +27,7 @@ class Like implements Filter
     private $value;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $dqlAlias;
 

--- a/src/Operand/Alias.php
+++ b/src/Operand/Alias.php
@@ -9,7 +9,7 @@ class Alias implements Operand
     /**
      * @var string
      */
-    private $alias = '';
+    private $alias;
 
     /**
      * @param string $alias

--- a/src/Operand/Field.php
+++ b/src/Operand/Field.php
@@ -10,10 +10,10 @@ class Field implements Operand, Selection
     /**
      * @var string
      */
-    private $fieldName = '';
+    private $fieldName;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $dqlAlias;
 

--- a/src/Operand/Value.php
+++ b/src/Operand/Value.php
@@ -19,7 +19,7 @@ class Value implements Operand
 
     /**
      * @param mixed           $value
-     * @param int|string|null $valueType PDO::PARAM_* or \Doctrine\DBAL\Types\Type::* constant
+     * @param int|string|null $valueType \PDO::PARAM_* or \Doctrine\DBAL\Types\Type::* constant
      */
     public function __construct($value, $valueType = null)
     {

--- a/src/Query/AbstractJoin.php
+++ b/src/Query/AbstractJoin.php
@@ -10,24 +10,24 @@ use Doctrine\ORM\QueryBuilder;
 abstract class AbstractJoin implements QueryModifier
 {
     /**
-     * @var string field
+     * @var string
      */
     private $field;
 
     /**
-     * @var string alias
+     * @var string
      */
     private $newAlias;
 
     /**
-     * @var string dqlAlias
+     * @var string|null
      */
     private $dqlAlias;
 
     /**
-     * @param string $field
-     * @param string $newAlias
-     * @param string $dqlAlias
+     * @param string      $field
+     * @param string      $newAlias
+     * @param string|null $dqlAlias
      */
     public function __construct($field, $newAlias, $dqlAlias = null)
     {

--- a/src/Query/GroupBy.php
+++ b/src/Query/GroupBy.php
@@ -14,13 +14,13 @@ class GroupBy implements QueryModifier
     protected $field;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $dqlAlias;
 
     /**
      * @param Field|Alias|string $field
-     * @param string             $dqlAlias
+     * @param string|null        $dqlAlias
      */
     public function __construct($field, $dqlAlias = null)
     {

--- a/src/Query/IndexBy.php
+++ b/src/Query/IndexBy.php
@@ -2,6 +2,7 @@
 
 namespace Happyr\DoctrineSpecification\Query;
 
+use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Operand\Field;
 
@@ -11,24 +12,18 @@ use Happyr\DoctrineSpecification\Operand\Field;
 class IndexBy implements QueryModifier
 {
     /**
-     * Field.
-     *
      * @var Field
      */
     private $field;
 
     /**
-     * DQL Alias.
-     *
-     * @var string
+     * @var string|null
      */
     private $dqlAlias;
 
     /**
-     * IndexBy constructor.
-     *
      * @param Field|string $field    Field name for indexing
-     * @param string       $dqlAlias DQL alias of field
+     * @param string|null  $dqlAlias DQL alias of field
      */
     public function __construct($field, $dqlAlias = null)
     {
@@ -40,7 +35,10 @@ class IndexBy implements QueryModifier
     }
 
     /**
-     * {@inheritdoc}
+     * @param QueryBuilder $qb
+     * @param string       $dqlAlias
+     *
+     * @throws QueryException
      */
     public function modify(QueryBuilder $qb, $dqlAlias)
     {

--- a/src/Query/OrderBy.php
+++ b/src/Query/OrderBy.php
@@ -19,7 +19,7 @@ class OrderBy implements QueryModifier
     protected $order;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $dqlAlias;
 

--- a/src/Spec.php
+++ b/src/Spec.php
@@ -159,9 +159,9 @@ class Spec
      */
 
     /**
-     * @param string $field
-     * @param string $newAlias
-     * @param string $dqlAlias
+     * @param string      $field
+     * @param string      $newAlias
+     * @param string|null $dqlAlias
      *
      * @return Join
      */
@@ -171,9 +171,9 @@ class Spec
     }
 
     /**
-     * @param string $field
-     * @param string $newAlias
-     * @param string $dqlAlias
+     * @param string      $field
+     * @param string      $newAlias
+     * @param string|null $dqlAlias
      *
      * @return LeftJoin
      */
@@ -183,9 +183,9 @@ class Spec
     }
 
     /**
-     * @param string $field
-     * @param string $newAlias
-     * @param string $dqlAlias
+     * @param string      $field
+     * @param string      $newAlias
+     * @param string|null $dqlAlias
      *
      * @return InnerJoin
      */
@@ -195,8 +195,8 @@ class Spec
     }
 
     /**
-     * @param string $field
-     * @param string $dqlAlias
+     * @param Field|string $field
+     * @param string|null  $dqlAlias
      *
      * @return IndexBy
      */
@@ -237,9 +237,9 @@ class Spec
     }
 
     /**
-     * @param string      $field
-     * @param string      $order
-     * @param string|null $dqlAlias
+     * @param Field|Alias|string $field
+     * @param string             $order
+     * @param string|null        $dqlAlias
      *
      * @return OrderBy
      */
@@ -249,8 +249,8 @@ class Spec
     }
 
     /**
-     * @param string $field
-     * @param string $dqlAlias
+     * @param Field|Alias|string $field
+     * @param string|null        $dqlAlias
      *
      * @return GroupBy
      */
@@ -400,9 +400,9 @@ class Spec
     /**
      * Make sure the $field has a value equals to $value.
      *
-     * @param string $field
-     * @param mixed  $value
-     * @param string $dqlAlias
+     * @param Operand|string $field
+     * @param Operand|mixed  $value
+     * @param string|null    $dqlAlias
      *
      * @return In
      */
@@ -412,9 +412,9 @@ class Spec
     }
 
     /**
-     * @param string $field
-     * @param mixed  $value
-     * @param string $dqlAlias
+     * @param Operand|string $field
+     * @param Operand|mixed  $value
+     * @param string|null    $dqlAlias
      *
      * @return Not
      */
@@ -496,10 +496,10 @@ class Spec
     }
 
     /**
-     * @param Operand|string $field
-     * @param string         $value
-     * @param string         $format
-     * @param string|null    $dqlAlias
+     * @param Operand|string     $field
+     * @param LikePattern|string $value
+     * @param string             $format
+     * @param string|null        $dqlAlias
      *
      * @return Like
      */


### PR DESCRIPTION
|  Line   |DBALTypesResolver.php
| ------ |------------------------------------------------------------------------------------------------------------
|  43     |Parameter # 1 `$key` of function `array_key_exists` expects `int\|string`, `string\|null` given.
|  44     |Parameter # 1 `$name` of static method `Doctrine\DBAL\Types\Type::getType()` expects string, `string\|null` given.

|  Line   |Filter/Comparison.php
| ------ |----------------------------------------------------------------------------------------------------------
|  82     |Property `Happyr\DoctrineSpecification\Filter\Comparison::$dqlAlias` (`string`) does not accept `string\|null`.

|  Line   |Filter/In.php
| ------ |--------------------------------------------------------------------------------------------------
|  37     |Property `Happyr\DoctrineSpecification\Filter\In::$dqlAlias` (`string`) does not accept `string\|null`.

|  Line   |Filter/Like.php
| ------ |----------------------------------------------------------------------------------------------------
|  47     |Property `Happyr\DoctrineSpecification\Filter\Like::$dqlAlias` (`string`) does not accept `string\|null`.

|  Line   |Operand/Field.php
| ------ |------------------------------------------------------------------------------------------------------
|  27     |Property `Happyr\DoctrineSpecification\Operand\Field::$dqlAlias` (`string`) does not accept `string\|null`.

|  Line   |Query/AbstractJoin.php
| ------ |-----------------------------------------------------------------------------------------------------------
|  36     |Property `Happyr\DoctrineSpecification\Query\AbstractJoin::$dqlAlias` (`string`) does not accept `string\|null`.

|  Line   |Query/GroupBy.php
| ------ |------------------------------------------------------------------------------------------------------
|  32     |Property `Happyr\DoctrineSpecification\Query\GroupBy::$dqlAlias` (`string`) does not accept `string\|null`.

|  Line   |Query/IndexBy.php
| ------ |------------------------------------------------------------------------------------------------------
|  39     |Property `Happyr\DoctrineSpecification\Query\IndexBy::$dqlAlias` (`string`) does not accept `string\|null`.

|  Line   |Query/OrderBy.php
| ------ |------------------------------------------------------------------------------------------------------
|  39     |Property `Happyr\DoctrineSpecification\Query\OrderBy::$dqlAlias` (`string`) does not accept `string\|null`.
