### PR TITLE
Use short array syntax recommended by PSR-2

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -3,6 +3,7 @@
 return PhpCsFixer\Config::create()
     ->setRules([
         '@Symfony' => true,
+        'array_syntax' => ['syntax' => 'short'],
         'ordered_imports' => [
             'sort_algorithm' => 'alpha',
         ],

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -2,3 +2,4 @@ preset: symfony
 
 enabled:
   - ordered_class_elements
+  - short_array_syntax

--- a/src/DBALTypesResolver.php
+++ b/src/DBALTypesResolver.php
@@ -11,7 +11,7 @@ final class DBALTypesResolver
      *
      * @var array
      */
-    private static $typesMap = array();
+    private static $typesMap = [];
 
     /**
      * Try get type for value.

--- a/src/Filter/Comparison.php
+++ b/src/Filter/Comparison.php
@@ -45,11 +45,11 @@ class Comparison implements Filter
     /**
      * @var array
      */
-    private static $operators = array(
+    private static $operators = [
         self::EQ, self::NEQ,
         self::LT, self::LTE,
         self::GT, self::GTE,
-    );
+    ];
 
     /**
      * @var string

--- a/src/Logic/LogicX.php
+++ b/src/Logic/LogicX.php
@@ -32,7 +32,7 @@ class LogicX implements Specification
      * @param string                   $expression
      * @param Filter[]|QueryModifier[] $children
      */
-    public function __construct($expression, array $children = array())
+    public function __construct($expression, array $children = [])
     {
         $this->expression = $expression;
         $this->children = $children;

--- a/src/Operand/Arithmetic.php
+++ b/src/Operand/Arithmetic.php
@@ -20,13 +20,13 @@ abstract class Arithmetic implements Operand
     /**
      * @var string[]
      */
-    private static $operations = array(
+    private static $operations = [
         self::ADD,
         self::SUB,
         self::MUL,
         self::DIV,
         self::MOD,
-    );
+    ];
 
     /**
      * @var string

--- a/src/Operand/Bitwise.php
+++ b/src/Operand/Bitwise.php
@@ -20,10 +20,10 @@ abstract class Bitwise implements Operand
     /**
      * @var string[]
      */
-    private static $operations = array(
+    private static $operations = [
         self::B_AND,
         self::B_OR,
-    );
+    ];
 
     /**
      * @var string

--- a/tests/Filter/ComparisonSpec.php
+++ b/tests/Filter/ComparisonSpec.php
@@ -50,11 +50,11 @@ class ComparisonSpec extends ObjectBehavior
 
     public function it_validates_operator()
     {
-        $this->shouldThrow(InvalidArgumentException::class)->during('__construct', array('==', 'age', 18, null));
+        $this->shouldThrow(InvalidArgumentException::class)->during('__construct', ['==', 'age', 18, null]);
     }
 
     public function it_not_support_like_operator()
     {
-        $this->shouldThrow(InvalidArgumentException::class)->during('__construct', array('like', 'name', 'Tobias%', null));
+        $this->shouldThrow(InvalidArgumentException::class)->during('__construct', ['like', 'name', 'Tobias%', null]);
     }
 }

--- a/tests/Filter/InSpec.php
+++ b/tests/Filter/InSpec.php
@@ -16,7 +16,7 @@ class InSpec extends ObjectBehavior
 {
     private $field = 'foobar';
 
-    private $value = array('bar', 'baz');
+    private $value = ['bar', 'baz'];
 
     public function let()
     {

--- a/tests/Logic/LogicXSpec.php
+++ b/tests/Logic/LogicXSpec.php
@@ -18,7 +18,7 @@ class LogicXSpec extends ObjectBehavior
 
     public function let(Specification $specificationA, Specification $specificationB)
     {
-        $this->beConstructedWith(self::EXPRESSION, array($specificationA, $specificationB));
+        $this->beConstructedWith(self::EXPRESSION, [$specificationA, $specificationB]);
     }
 
     public function it_is_a_specification()
@@ -51,7 +51,7 @@ class LogicXSpec extends ObjectBehavior
 
     public function it_supports_expressions(QueryBuilder $qb, Expr $expression, Filter $exprA, Filter $exprB, $x, $y)
     {
-        $this->beConstructedWith(self::EXPRESSION, array($exprA, $exprB));
+        $this->beConstructedWith(self::EXPRESSION, [$exprA, $exprB]);
 
         $dqlAlias = 'a';
 

--- a/tests/Operand/ArgumentToOperandConverterSpec.php
+++ b/tests/Operand/ArgumentToOperandConverterSpec.php
@@ -41,24 +41,24 @@ class ArgumentToOperandConverterSpec extends ObjectBehavior
 
     public function it_is_all_arguments_a_operands(Operand $first, Operand $second)
     {
-        $arguments = array($first, $second);
+        $arguments = [$first, $second];
         $this->isAllOperands($arguments)->shouldReturn(true);
     }
 
     public function it_is_not_all_arguments_a_operands(Operand $first, Operand $second)
     {
-        $arguments = array($first, 'foo', $second);
+        $arguments = [$first, 'foo', $second];
         $this->isAllOperands($arguments)->shouldReturn(false);
     }
 
     public function it_no_nothing_to_convert()
     {
-        $this->convert(array())->shouldReturn([]);
+        $this->convert([])->shouldReturn([]);
     }
 
     public function it_a_convertible_field()
     {
-        $subject = $this->convert(array('foo'));
+        $subject = $this->convert(['foo']);
         $subject->shouldBeArray();
         $subject->shouldHaveCount(1);
         $subject->shouldHaveField();
@@ -66,12 +66,12 @@ class ArgumentToOperandConverterSpec extends ObjectBehavior
 
     public function it_a_already_converted_field(Operand $field)
     {
-        $this->convert(array($field))->shouldReturn(array($field));
+        $this->convert([$field])->shouldReturn([$field]);
     }
 
     public function it_a_convertible_field_and_value()
     {
-        $subject = $this->convert(array('foo', 'bar'));
+        $subject = $this->convert(['foo', 'bar']);
         $subject->shouldBeArray();
         $subject->shouldHaveCount(2);
         $subject->shouldHaveField();
@@ -80,12 +80,12 @@ class ArgumentToOperandConverterSpec extends ObjectBehavior
 
     public function it_a_already_converted_value(Operand $field, Operand $value)
     {
-        $this->convert(array($field, $value))->shouldReturn(array($field, $value));
+        $this->convert([$field, $value])->shouldReturn([$field, $value]);
     }
 
     public function it_a_already_converted_value2(Operand $value)
     {
-        $subject = $this->convert(array('foo', $value));
+        $subject = $this->convert(['foo', $value]);
         $subject->shouldBeArray();
         $subject->shouldHaveCount(2);
         $subject->shouldHaveField();
@@ -94,7 +94,7 @@ class ArgumentToOperandConverterSpec extends ObjectBehavior
 
     public function it_a_convertible_arguments(Operand $first, Operand $second)
     {
-        $subject = $this->convert(array('foo', $first, $second, 'bar'));
+        $subject = $this->convert(['foo', $first, $second, 'bar']);
         $subject->shouldBeArray();
         $subject->shouldHaveCount(4);
         $subject->shouldHaveField();
@@ -106,12 +106,12 @@ class ArgumentToOperandConverterSpec extends ObjectBehavior
     public function it_is_not_convertible_arguments(Field $field, Operand $operand, Value $value)
     {
         $this->shouldThrow(NotConvertibleException::class)
-            ->duringConvert(array($field, $operand, 'foo', $value));
+            ->duringConvert([$field, $operand, 'foo', $value]);
     }
 
     public function getMatchers()
     {
-        return array(
+        return [
             'haveField' => function ($subject) {
                 return $subject[0] instanceof Field;
             },
@@ -121,6 +121,6 @@ class ArgumentToOperandConverterSpec extends ObjectBehavior
             'haveOperandAt' => function ($subject, $position) {
                 return $subject[$position] instanceof Operand;
             },
-        );
+        ];
     }
 }

--- a/tests/Operand/PlatformFunctionSpec.php
+++ b/tests/Operand/PlatformFunctionSpec.php
@@ -138,13 +138,13 @@ class PlatformFunctionSpec extends ObjectBehavior
         $configuration->getCustomDatetimeFunction($functionName)->willReturn(null);
 
         $this->beConstructedWith($functionName, 'foo');
-        $this->shouldThrow(InvalidArgumentException::class)->during('transform', array($qb, 'a'));
+        $this->shouldThrow(InvalidArgumentException::class)->during('transform', [$qb, 'a']);
     }
 
     public function it_is_transformable_not_convertible(QueryBuilder $qb)
     {
         $this->beConstructedWith('concat', ['foo', 'bar', 'baz']);
 
-        $this->shouldThrow(NotConvertibleException::class)->during('transform', array($qb, 'a'));
+        $this->shouldThrow(NotConvertibleException::class)->during('transform', [$qb, 'a']);
     }
 }


### PR DESCRIPTION
[PSR-2](https://www.php-fig.org/psr/psr-2/) does not mention short array syntax, but in [chapter 4.3](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md#43-methods) they use short array syntax to set the default value of `$arg3` to be an empty array.

So for PHP >= 5.4 the short array syntax seems to be the de-facto standard. The `array()` shold be used only for script to run on PHP < 5.4.