### PR TITLE
Optimize convert several arguments to Operand

### DIFF
--- a/src/Operand/ArgumentToOperandConverter.php
+++ b/src/Operand/ArgumentToOperandConverter.php
@@ -70,32 +70,21 @@ class ArgumentToOperandConverter
      */
     public static function convert(array $arguments)
     {
-        if (!$arguments) {
-            return [];
-        }
-
-        // always try convert the first argument to the field operand
-        $field = self::toField(array_shift($arguments));
-
-        if (!$arguments) {
-            return [$field];
-        }
-
-        // always try convert the last argument to the value operand
-        $value = self::toValue(array_pop($arguments));
-
-        if (!$arguments) {
-            return [$field, $value];
-        }
-
-        $result = [$field];
-        foreach ($arguments as $argument) {
-            if (!($argument instanceof Operand)) {
+        $result = [];
+        $size = count($arguments);
+        foreach (array_values($arguments) as $i => $argument) {
+            if (0 === $i) {
+                // always try convert the first argument to the field operand
+                $argument = self::toField($argument);
+            } elseif ($i === $size - 1) {
+                // always try convert the last argument to the value operand
+                $argument = self::toValue($argument);
+            } elseif (!($argument instanceof Operand)) {
                 throw new NotConvertibleException('You passed arguments not all of which are operands.');
             }
-            $result[] = $argument;
+
+            $result[$i] = $argument;
         }
-        $result[] = $value;
 
         return $result;
     }

--- a/src/Operand/ArgumentToOperandConverter.php
+++ b/src/Operand/ArgumentToOperandConverter.php
@@ -83,7 +83,7 @@ class ArgumentToOperandConverter
                 throw new NotConvertibleException('You passed arguments not all of which are operands.');
             }
 
-            $result[$i] = $argument;
+            $result[] = $argument;
         }
 
         return $result;

--- a/src/Operand/PlatformFunction.php
+++ b/src/Operand/PlatformFunction.php
@@ -89,8 +89,8 @@ class PlatformFunction implements Operand
         }
 
         $arguments = [];
-        foreach (ArgumentToOperandConverter::convert($this->arguments) as $key => $argument) {
-            $arguments[$key] = $argument->transform($qb, $dqlAlias);
+        foreach (ArgumentToOperandConverter::convert($this->arguments) as $argument) {
+            $arguments[] = $argument->transform($qb, $dqlAlias);
         }
 
         return sprintf('%s(%s)', $this->functionName, implode(', ', $arguments));


### PR DESCRIPTION
The expression `$arguments` of type `array<Happyr\DoctrineSpecification\Operand\Operand|string>` is implicitly converted to a boolean; are you sure this is intended? If so, consider using `empty($expr)` instead to make it clear that you intend to check for an array without elements.
Filename: `src/Operand/ArgumentToOperandConverter.php`
LineNumber: `73`
Link: https://scrutinizer-ci.com/g/Happyr/Doctrine-Specification/issues/master/files/src/Operand/ArgumentToOperandConverter.php?selectedLabels%5B0%5D=9&orderField=path&order=asc&honorSelectedPaths=0&issueId=36119903

It seems like `array_shift($arguments)` targeting `array_shift()` can also be of type `null`; however, `Happyr\DoctrineSpecification\Operand\ArgumentToOperandConverter::toField()` does only seem to accept `object<Happyr\DoctrineSpecification\Operand\Operand>|string`, maybe add an additional type check?
Filename: `src/Operand/ArgumentToOperandConverter.php`
LineNumber: `78`
Link: https://scrutinizer-ci.com/g/Happyr/Doctrine-Specification/issues/master/files/src/Operand/ArgumentToOperandConverter.php?selectedLabels%5B0%5D=9&orderField=path&order=asc&honorSelectedPaths=0&issueId=36119902

The expression `$arguments` of type `array` is implicitly converted to a boolean; are you sure this is intended? If so, consider using `empty($expr)` instead to make it clear that you intend to check for an array without elements.  
Filename: `src/Operand/ArgumentToOperandConverter.php`
LineNumber: `80`
Link: https://scrutinizer-ci.com/g/Happyr/Doctrine-Specification/issues/master/files/src/Operand/ArgumentToOperandConverter.php?selectedLabels%5B0%5D=9&orderField=path&order=asc&honorSelectedPaths=0&issueId=36119904

The expression `$arguments` of type `array` is implicitly converted to a boolean; are you sure this is intended? If so, consider using `empty($expr)` instead to make it clear that you intend to check for an array without elements.
Filename: `src/Operand/ArgumentToOperandConverter.php`
LineNumber: `87`
Link: https://scrutinizer-ci.com/g/Happyr/Doctrine-Specification/issues/master/files/src/Operand/ArgumentToOperandConverter.php?selectedLabels%5B0%5D=9&orderField=path&order=asc&honorSelectedPaths=0&issueId=36119905