### PR TITLE
Run PHPStan for low version of PHP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     - php: 5.6
     - php: 5.5
       dist: trusty
-    - php: 7.3
+    - php: 7.0
       env: PHPSTAN_VERSION=0.11.*
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     - php: 5.6
     - php: 5.5
       dist: trusty
-    - php: 7.0
+    - php: 7.1
       env: PHPSTAN_VERSION=0.11.*
 
 install:


### PR DESCRIPTION
Testing on lower versions of PHP increases project support for users using an older version of PHP.