### PR TITLE
Empty filter

### DIFF
--- a/src/EntitySpecificationRepositoryTrait.php
+++ b/src/EntitySpecificationRepositoryTrait.php
@@ -223,8 +223,9 @@ trait EntitySpecificationRepositoryTrait
             $specification->modify($queryBuilder, $alias ?: $this->getAlias());
         }
 
-        if ($specification instanceof Filter
-            && $filter = $specification->getFilter($queryBuilder, $alias ?: $this->getAlias())
+        if ($specification instanceof Filter &&
+            ($filter = $specification->getFilter($queryBuilder, $alias ?: $this->getAlias())) &&
+            ($filter = trim($filter))
         ) {
             $queryBuilder->andWhere($filter);
         }

--- a/src/Logic/LogicX.php
+++ b/src/Logic/LogicX.php
@@ -64,6 +64,10 @@ class LogicX implements Specification
             }
         }
 
+        if (!$children) {
+            return '';
+        }
+
         $expression = [$qb->expr(), $this->expression];
 
         if (!is_callable($expression)) {


### PR DESCRIPTION
fix #232

The problem is that an empty filter appears that contains only spaces.

* Not apply expression for empty list of children specifications in `LogicX`;
* Clear filter from spaces to detect empty filter.