### PR TITLE
Empty filter

### DIFF
--- a/src/EntitySpecificationRepositoryTrait.php
+++ b/src/EntitySpecificationRepositoryTrait.php
@@ -212,8 +212,9 @@ trait EntitySpecificationRepositoryTrait
             $specification->modify($queryBuilder, $alias ?: $this->getAlias());
         }
 
-        if ($specification instanceof Filter
-            && $filter = (string) $specification->getFilter($queryBuilder, $alias ?: $this->getAlias())
+        if ($specification instanceof Filter &&
+            ($filter = (string) $specification->getFilter($queryBuilder, $alias ?: $this->getAlias())) &&
+            ($filter = trim($filter))
         ) {
             $queryBuilder->andWhere($filter);
         }

--- a/src/Logic/LogicX.php
+++ b/src/Logic/LogicX.php
@@ -53,6 +53,10 @@ class LogicX implements Specification
             }
         }
 
+        if (!$children) {
+            return '';
+        }
+
         return call_user_func_array(array($qb->expr(), $this->expression), $children);
     }
 


### PR DESCRIPTION
fix #232

The problem is that an empty filter appears that contains only spaces.

* Not apply expression for empty list of children specifications in `LogicX`;
* Clear filter from spaces to detect empty filter.