### PR TITLE
Disable single_line_throw and no_superfluous_phpdoc_tags rules

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -19,6 +19,8 @@ return PhpCsFixer\Config::create()
             'header' => $header,
         ],
         'array_syntax' => ['syntax' => 'short'],
+        'no_superfluous_phpdoc_tags' => false,
+        'single_line_throw' => false,
         'ordered_imports' => [
             'sort_algorithm' => 'alpha',
         ],

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,5 +1,9 @@
 preset: symfony
 
 enabled:
-  - ordered_class_elements
-  - short_array_syntax
+    - ordered_class_elements
+    - short_array_syntax
+
+disable:
+    - single_line_throw
+    - no_superfluous_phpdoc_tags

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -6,4 +6,3 @@ enabled:
 
 disabled:
     - single_line_throw
-    - no_superfluous_phpdoc_tags

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -4,6 +4,6 @@ enabled:
     - ordered_class_elements
     - short_array_syntax
 
-disable:
+disabled:
     - single_line_throw
     - no_superfluous_phpdoc_tags


### PR DESCRIPTION
The `single_line_throw` and `no_superfluous_phpdoc_tags` is not recommended.