### PR TITLE
MemberOfX::getFilter() and LogicX::getFilter() should return a string

### DIFF
--- a/src/Filter/MemberOfX.php
+++ b/src/Filter/MemberOfX.php
@@ -61,7 +61,7 @@ class MemberOfX implements Filter
         $field = ArgumentToOperandConverter::toField($this->field);
         $value = ArgumentToOperandConverter::toValue($this->value);
 
-        return $qb->expr()->isMemberOf(
+        return (string) $qb->expr()->isMemberOf(
             $value->transform($qb, $dqlAlias),
             $field->transform($qb, $dqlAlias)
         );

--- a/src/Logic/LogicX.php
+++ b/src/Logic/LogicX.php
@@ -78,7 +78,7 @@ class LogicX implements Specification
             );
         }
 
-        return call_user_func_array($expression, $children);
+        return (string) call_user_func_array($expression, $children);
     }
 
     /**

--- a/tests/Filter/MemberOfXSpec.php
+++ b/tests/Filter/MemberOfXSpec.php
@@ -41,12 +41,9 @@ class MemberOfXSpec extends ObjectBehavior
         $this->shouldBeAnInstanceOf(Filter::class);
     }
 
-    public function it_returns_expression_func_object(
-        QueryBuilder $qb,
-        ArrayCollection $parameters,
-        Expr $exp,
-        Comparison $exp_comparison
-    ) {
+    public function it_returns_expression_func_object(QueryBuilder $qb, ArrayCollection $parameters, Expr $exp)
+    {
+        $exp_comparison = new Comparison(':comparison_10', 'MEMBER OF', 'a.age');
         $qb->expr()->willReturn($exp);
         $qb->getParameters()->willReturn($parameters);
         $parameters->count()->willReturn(10);
@@ -54,8 +51,6 @@ class MemberOfXSpec extends ObjectBehavior
         $qb->setParameter('comparison_10', 18, null)->shouldBeCalled();
         $exp->isMemberOf(':comparison_10', 'a.age')->willReturn($exp_comparison);
 
-        $comparison = $this->getFilter($qb, null);
-
-        $comparison->shouldReturn($exp_comparison);
+        $this->getFilter($qb, null)->shouldReturn(':comparison_10 MEMBER OF a.age');
     }
 }


### PR DESCRIPTION
Now `MemberOfX::getFilter()` return a stringable `\Doctrine\ORM\Query\Expr\Comparison` object and `LogicX::getFilter()` return a stringable `\Doctrine\ORM\Query\Expr\Andx` or `\Doctrine\ORM\Query\Expr\Orx` object.