### PR TITLE
Remove short_array_syntax CS fixer

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -2,7 +2,6 @@ preset: symfony
 
 enabled:
     - ordered_class_elements
-    - short_array_syntax
 
 disabled:
     - single_line_throw


### PR DESCRIPTION
Fix error in Style CI config

> Config Issue
> The 'short_array_syntax' fixer cannot be enabled again because it has already been enabled.