### PR TITLE
Disable no_superfluous_phpdoc_tags in Style CI config

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -5,3 +5,4 @@ enabled:
 
 disabled:
     - single_line_throw
+    - no_superfluous_phpdoc_tags_symfony


### PR DESCRIPTION
The `no_superfluous_phpdoc_tags`  fix rule has been added to the Style CI config, so we can disable it like in [.php_cs.dist](https://github.com/Happyr/Doctrine-Specification/blob/master/.php_cs.dist#L22).