### PR TITLE
Fix BC with Doctrine ORM 2.2

### DIFF
--- a/src/Filter/MemberOfX.php
+++ b/src/Filter/MemberOfX.php
@@ -61,6 +61,11 @@ class MemberOfX implements Filter
         $field = ArgumentToOperandConverter::toField($this->field);
         $value = ArgumentToOperandConverter::toValue($this->value);
 
+        // doctrine/orm < 2.5
+        if (!method_exists($qb, 'isMemberOf')) {
+            return sprintf('%s MEMBER OF %s', $value->transform($qb, $dqlAlias), $field->transform($qb, $dqlAlias));
+        }
+
         return (string) $qb->expr()->isMemberOf(
             $value->transform($qb, $dqlAlias),
             $field->transform($qb, $dqlAlias)

--- a/src/Query/IndexBy.php
+++ b/src/Query/IndexBy.php
@@ -57,6 +57,11 @@ class IndexBy implements QueryModifier
             $dqlAlias = $this->dqlAlias;
         }
 
+        // doctrine/orm < 2.5
+        if (!method_exists($qb, 'indexBy')) {
+            throw new \RuntimeException('IndexBy query modifier require doctrine/orm >= 2.5');
+        }
+
         $qb->indexBy($dqlAlias, $this->field->transform($qb, $dqlAlias));
     }
 }

--- a/tests/Filter/MemberOfXSpec.php
+++ b/tests/Filter/MemberOfXSpec.php
@@ -14,8 +14,6 @@
 namespace tests\Happyr\DoctrineSpecification\Filter;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\ORM\Query\Expr;
-use Doctrine\ORM\Query\Expr\Comparison;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Filter\Filter;
 use Happyr\DoctrineSpecification\Filter\MemberOfX;
@@ -41,15 +39,12 @@ class MemberOfXSpec extends ObjectBehavior
         $this->shouldBeAnInstanceOf(Filter::class);
     }
 
-    public function it_returns_expression_func_object(QueryBuilder $qb, ArrayCollection $parameters, Expr $exp)
+    public function it_returns_expression_func_object(QueryBuilder $qb, ArrayCollection $parameters)
     {
-        $exp_comparison = new Comparison(':comparison_10', 'MEMBER OF', 'a.age');
-        $qb->expr()->willReturn($exp);
         $qb->getParameters()->willReturn($parameters);
         $parameters->count()->willReturn(10);
 
         $qb->setParameter('comparison_10', 18, null)->shouldBeCalled();
-        $exp->isMemberOf(':comparison_10', 'a.age')->willReturn($exp_comparison);
 
         $this->getFilter($qb, null)->shouldReturn(':comparison_10 MEMBER OF a.age');
     }

--- a/tests/Operand/PlatformFunctionSpec.php
+++ b/tests/Operand/PlatformFunctionSpec.php
@@ -15,7 +15,7 @@ namespace tests\Happyr\DoctrineSpecification\Operand;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Configuration;
-use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Exception\InvalidArgumentException;
 use Happyr\DoctrineSpecification\Operand\Field;
@@ -78,7 +78,7 @@ class PlatformFunctionSpec extends ObjectBehavior
 
     public function it_is_transformable_custom_string_function(
         QueryBuilder $qb,
-        EntityManagerInterface $em,
+        EntityManager $em,
         Configuration $configuration
     ) {
         $dqlAlias = 'a';
@@ -98,7 +98,7 @@ class PlatformFunctionSpec extends ObjectBehavior
 
     public function it_is_transformable_custom_numeric_function(
         QueryBuilder $qb,
-        EntityManagerInterface $em,
+        EntityManager $em,
         Configuration $configuration
     ) {
         $dqlAlias = 'a';
@@ -118,7 +118,7 @@ class PlatformFunctionSpec extends ObjectBehavior
 
     public function it_is_transformable_custom_datetime_function(
         QueryBuilder $qb,
-        EntityManagerInterface $em,
+        EntityManager $em,
         Configuration $configuration
     ) {
         $dqlAlias = 'a';
@@ -138,7 +138,7 @@ class PlatformFunctionSpec extends ObjectBehavior
 
     public function it_is_transformable_undefined_function(
         QueryBuilder $qb,
-        EntityManagerInterface $em,
+        EntityManager $em,
         Configuration $configuration
     ) {
         $functionName = 'foo';
@@ -155,7 +155,7 @@ class PlatformFunctionSpec extends ObjectBehavior
 
     public function it_is_transformable_convertible(
         QueryBuilder $qb,
-        EntityManagerInterface $em,
+        EntityManager $em,
         Configuration $configuration,
         ArrayCollection $parameters,
         Value $value

--- a/tests/Query/IndexBySpec.php
+++ b/tests/Query/IndexBySpec.php
@@ -16,6 +16,7 @@ namespace tests\Happyr\DoctrineSpecification\Query;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Query\IndexBy;
 use PhpSpec\ObjectBehavior;
+use PhpSpec\Exception\Example\SkippingException;
 
 /**
  * @mixin IndexBy
@@ -33,11 +34,19 @@ class IndexBySpec extends ObjectBehavior
 
     public function it_is_a_result_modifier()
     {
+        if (!method_exists(QueryBuilder::class, 'indexBy')) {
+            throw new SkippingException('IndexBy query modifier require doctrine/orm >= 2.5');
+        }
+
         $this->shouldBeAnInstanceOf('Happyr\DoctrineSpecification\Query\QueryModifier');
     }
 
     public function it_indexes_with_default_dql_alias(QueryBuilder $qb)
     {
+        if (!method_exists(QueryBuilder::class, 'indexBy')) {
+            throw new SkippingException('IndexBy query modifier require doctrine/orm >= 2.5');
+        }
+
         $this->beConstructedWith('something', 'x');
         $qb->indexBy('x', 'x.something')->shouldBeCalled();
         $this->modify($qb, 'a');
@@ -45,6 +54,10 @@ class IndexBySpec extends ObjectBehavior
 
     public function it_uses_local_alias_if_global_was_not_set(QueryBuilder $qb)
     {
+        if (!method_exists(QueryBuilder::class, 'indexBy')) {
+            throw new SkippingException('IndexBy query modifier require doctrine/orm >= 2.5');
+        }
+
         $this->beConstructedWith('thing');
         $qb->indexBy('b', 'b.thing')->shouldBeCalled();
         $this->modify($qb, 'b');

--- a/tests/Result/RoundDateTimeSpec.php
+++ b/tests/Result/RoundDateTimeSpec.php
@@ -43,11 +43,18 @@ class RoundDateTimeSpec extends ObjectBehavior
         $actual = new \DateTime('15:55:34');
         $expected = new \DateTimeImmutable('15:00:00');
 
-        $query->getParameters()->willReturn(new ArrayCollection([
-            new Parameter('status', 'active'), // scalar param
-            new Parameter($name, $actual, $type),
-        ]));
-        $query->setParameter($name, $expected, $type)->shouldBeCalled();
+        if (class_exists(Parameter::class)) { // doctrine/orm >= 2.3
+            $query->getParameters()->willReturn(new ArrayCollection([
+                new Parameter('status', 'active'), // scalar param
+                new Parameter($name, $actual, $type),
+            ]));
+            $query->setParameter($name, $expected, $type)->shouldBeCalled();
+        } else {
+            $query->getParameters()->willReturn([
+                'status' => 'active', // scalar param
+                $name => $actual,
+            ]);
+        }
 
         $this->modify($query);
     }


### PR DESCRIPTION
BC with `doctrine/orm:2.2` was broken.

The method `\Doctrine\ORM\QueryBuilder::indexBy()` used in `IndexBy` was added in [2.5.0](https://github.com/doctrine/orm/blob/v2.5.0/lib/Doctrine/ORM/QueryBuilder.php#L907).
The method `\Doctrine\ORM\Query;\Expr::isMemberOf()` used in `MemberOfX` was added in [2.5.0](https://github.com/doctrine/orm/blob/v2.5.0/lib/Doctrine/ORM/Query/Expr.php#L656).
The class `\Doctrine\ORM\Query\Parameter` used in `RoundDateTimeSpec` was added in [2.3.0](https://github.com/doctrine/orm/blob/2.3.0/lib/Doctrine/ORM/Query/Parameter.php).
The class `\Doctrine\ORM\EntityManagerInterface` used in `PlatformFunctionSpec` was added in [2.4.0](https://github.com/doctrine/orm/blob/v2.4.0/lib/Doctrine/ORM/EntityManagerInterface.php).