### PR TITLE
Update PHPSpec to 6.3 and PHP to 7.2

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Install PHP with extensions
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.1
+          php-version: 7.2
           coverage: none
           tools: composer:v2
 
@@ -47,7 +47,7 @@ jobs:
       - name: Install PHP with extensions
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.1
+          php-version: 7.2
           coverage: none
           tools: composer:v2
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,38 +1,34 @@
 name: Test
 
-on:
-    push:
-        branches:
-    pull_request:
-        branches:
+on: [push, pull_request ]
 
 jobs:
     test:
         name: 'PHP ${{ matrix.php-version }} + ${{ matrix.dependencies }} + ${{ matrix.variant }}'
         runs-on: ubuntu-latest
-        continue-on-error: ${{ matrix.experimental }}
 
         strategy:
             fail-fast: false
             matrix:
                 dependencies:
-                    # TODO require phpspec/phpspec >= 6.3.0
-                    #- lowest
+                    - lowest
                     - highest
                 php-version:
-                    - '7.0'
-                    - '7.1'
                     - '7.2'
                     - '7.3'
                     - '7.4'
-                experimental: [false]
+                    - '8.0'
                 variant: [normal]
-                # TODO require phpspec/phpspec >= 6.3.0 and PHP >= 7.2
-#                include:
-#                    - php-version: '8.0'
-#                      dependencies: highest
-#                      variant: normal
-#                      experimental: true
+                include:
+                    - php-version: '7.2'
+                      dependencies: highest
+                      variant: 'doctrine/orm:~2.5'
+                    - php-version: '7.2'
+                      dependencies: highest
+                      variant: 'doctrine/orm:~2.6'
+                    - php-version: '7.2'
+                      dependencies: highest
+                      variant: 'doctrine/orm:~2.7'
         steps:
             - name: Checkout
               uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.2",
         "doctrine/orm": "~2.5"
     },
     "require-dev": {
-        "phpspec/phpspec": "~2.1"
+        "phpspec/phpspec": "~6.3"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Operand/ArgumentToOperandConverterSpec.php
+++ b/tests/Operand/ArgumentToOperandConverterSpec.php
@@ -125,7 +125,7 @@ class ArgumentToOperandConverterSpec extends ObjectBehavior
         $subject->shouldHaveValueAt(2);
     }
 
-    public function getMatchers()
+    public function getMatchers(): array
     {
         return [
             'haveField' => function ($subject) {


### PR DESCRIPTION
PHP 8 compatibility requires PHPSpec to be updated to `6.3`.
PHPSpec `6.3` [require](https://packagist.org/packages/phpspec/phpspec#6.3.0) PHP `^7.2`.