### PR TITLE
Use variable-length argument lists

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,79 +1,132 @@
 # Upgrade from 1.1 to 2.0
 
-The `AbstractJoin::getJoinType()` method was removed. Use `AbstractJoin::modifyJoin()` method inside.
-The `Comparison` class marked as `abstract`.
-The `LogicX` class marked as `abstract`.
-The `protected` properties in `Comparison` class marked as `private`.
-The `protected` properties in `In` class marked as `private`.
-The `protected` properties in `GroupBy` class marked as `private`.
-The `protected` properties in `OrderBy` class marked as `private`.
-The `protected` properties in `Limit` class marked as `private`.
-The `protected` properties in `Offset` class marked as `private`.
-The `Bitwise` operands was removed.
+* The `AbstractJoin::getJoinType()` method was removed. Use `AbstractJoin::modifyJoin()` method inside.
+* The `Comparison` class marked as `abstract`.
+* The `LogicX` class marked as `abstract`.
+* The `protected` properties in `Comparison` class marked as `private`.
+* The `protected` properties in `In` class marked as `private`.
+* The `protected` properties in `GroupBy` class marked as `private`.
+* The `protected` properties in `OrderBy` class marked as `private`.
+* The `protected` properties in `Limit` class marked as `private`.
+* The `protected` properties in `Offset` class marked as `private`.
+* The `Bitwise` operands was removed.
+* The `Happyr\DoctrineSpecification\Specification\Having` class was removed, use
+  `Happyr\DoctrineSpecification\Query\Having` instead.
+* Removes the ability to use `array` as argument for the `PlatformFunction` operand.
+
+  Before:
+
+  ```php
+  $arguments = ['create_at', new \DateTimeImmutable()];
+  Spec::DATE_DIFF($arguments);
+  Spec::fun('DATE_DIFF', $arguments);
+  new PlatformFunction('DATE_DIFF', $arguments);
+  ```
+
+  After:
+
+  ```php
+  $arguments = ['create_at', new \DateTimeImmutable()];
+  Spec::DATE_DIFF(...$arguments);
+  Spec::fun('DATE_DIFF', ...$arguments);
+  new PlatformFunction('DATE_DIFF', ...$arguments);
+  ```
+
+* Removes the ability to use `array` as argument for the `Select` query modifier.
+
+  Before:
+
+  ```php
+  $fields = ['title', 'cover'];
+  Spec::select($fields);
+  new Select($fields);
+  ```
+
+  After:
+
+  ```php
+  $fields = ['title', 'cover'];
+  Spec::select(...$fields);
+  new Select(...$fields);
+  ```
+
+* Removes the ability to use `array` as argument for the `AddSelect` query modifier.
+
+  Before:
+
+  ```php
+  $fields = ['title', 'cover'];
+  Spec::addSelect($fields);
+  new AddSelect($fields);
+  ```
+
+  After:
+
+  ```php
+  $fields = ['title', 'cover'];
+  Spec::addSelect(...$fields);
+  new AddSelect(...$fields);
+  ```
 
 # Upgrade from 1.0 to 1.1
 
-No BC breaks
+* No BC breaks
 
 # Upgrade from 0.8 to 1.0
 
-The `Comparison` no longer supports the operator `LIKE`. Use the `Like` filter.
-The `Like` filter no longer expands the `Comparison` base filter.
-The `IsNotNull` filter no longer expands the `IsNull` base filter.
-The `Happyr\DoctrineSpecification\Specification\Having` class was removed, use `Happyr\DoctrineSpecification\Query\Having` instead.
+* The `Comparison` no longer supports the operator `LIKE`. Use the `Like` filter.
+* The `Like` filter no longer expands the `Comparison` base filter.
+* The `IsNotNull` filter no longer expands the `IsNull` base filter.
 
 # Upgrade from 0.7 to 0.8
 
-The `CountOf` specification not expect a `Specification` as argument.
-The `ResultModifier` in `EntitySpecificationRepositoryInterface` method arguments now is nullable.
-Added new method `EntitySpecificationRepositoryInterface::getQueryBuilder()` and
-`EntitySpecificationRepositoryTrait::getQueryBuilder()` for get Doctrine QueryBuilder with specification.
+* The `CountOf` specification not expect a `Specification` as argument.
+* The `ResultModifier` in `EntitySpecificationRepositoryInterface` method arguments now is nullable.
+* Added new method `EntitySpecificationRepositoryInterface::getQueryBuilder()` and
+  `EntitySpecificationRepositoryTrait::getQueryBuilder()` for get Doctrine QueryBuilder with specification.
 
 # Upgrade from 0.6 to 0.7
 
-Removed `AsSingle` result modifier. Consider using `AsSingleScalar`.
+* Removed `AsSingle` result modifier. Consider using `AsSingleScalar`.
 
 # Upgrade from 0.5 to 0.6
 
-No BC breaks
+* No BC breaks
 
 # Upgrade from 0.4 to 0.5
 
-Moved `Happyr\DoctrineSpecification\Specification` to `Happyr\DoctrineSpecification\Specification\Specification`.
+* Moved `Happyr\DoctrineSpecification\Specification` to `Happyr\DoctrineSpecification\Specification\Specification`.
 
 # Upgrade from 0.3 to 0.4
 
 ## BaseSpecification
 
-Merged `getFilterInstance` and `getQueryModifierInstance` into `getSpec`. The new function should return a `Filter`
-and/or a `QueryBuilder`. We did this to make the API easier.
+* Merged `getFilterInstance` and `getQueryModifierInstance` into `getSpec`. The new function should return a `Filter`
+  and/or a `QueryBuilder`. We did this to make the API easier.
 
 ## LogicX
 
-You can now do `Spec::andx(new MyFilter(), new MyQueryModifier);` with both `Filter`s and `QueryBuilder`s.
+* You can now do `Spec::andx(new MyFilter(), new MyQueryModifier);` with both `Filter`s and `QueryBuilder`s.
 
 # Upgrade from 0.2 to 0.3
 
-It has been many changes since 0.2 and we refactored quite a lot. These are the biggest changes.
+* It has been many changes since 0.2 and we refactored quite a lot. These are the biggest changes.
 
 ## Changed interfaces
 
-The old `Specification` interface has been split up to two parts. We got a `Filter` with will modify the `SELECT`
-clause of the SQL query. We also got the `QueryModifier` interface the modifies the query (Limit, Order, Join etc).
-
-The new `Specification` interface extends `Filter` and `QueryModifier`.
-
-You have to update your specifications to comply with `QueryModifier` and/or `Expression`
+* The old `Specification` interface has been split up to two parts. We got a `Filter` with will modify the `SELECT`
+  clause of the SQL query. We also got the `QueryModifier` interface the modifies the query (Limit, Order, Join etc).
+* The new `Specification` interface extends `Filter` and `QueryModifier`.
+* You have to update your specifications to comply with `QueryModifier` and/or `Expression`
 
 
 ## BaseSpecification
 
-There are two new methods `getFilter` and `modify`. You don't need to override these. You may use BaseSpecfication as
-normal.
-
-The `supports` function has been removed.
+* There are two new methods `getFilter` and `modify`. You don't need to override these. You may use BaseSpecfication as
+  normal.
+* The `supports` function has been removed.
 
 ## EntitySpecificationRepository
 
-The `match` method has changed to take a second optional parameter of a `ResultModifier`. You may modify the result by
-changing the hydration mode or to add a cache. We decided that it would not be a part of a `Specification`.
+* The `match` method has changed to take a second optional parameter of a `ResultModifier`. You may modify the result
+  by changing the hydration mode or to add a cache. We decided that it would not be a part of a `Specification`.

--- a/docs/0-usage.md
+++ b/docs/0-usage.md
@@ -277,18 +277,14 @@ With one argument:
 
 ```php
 Spec::LENGTH('email');
-Spec::LENGTH(['email']);
 Spec::fun('LENGTH', 'email');
-Spec::fun('LENGTH', ['email']);
 ```
 
 With several arguments:
 
 ```php
 Spec::DATE_DIFF('create_at', $date);
-Spec::DATE_DIFF(['create_at', $date]);
 Spec::fun('DATE_DIFF', 'create_at', $date);
-Spec::fun('DATE_DIFF', ['create_at', $date]);
 ```
 
 # Customize selection

--- a/src/Logic/AndX.php
+++ b/src/Logic/AndX.php
@@ -19,10 +19,12 @@ use Happyr\DoctrineSpecification\Query\QueryModifier;
 
 class AndX extends LogicX
 {
-    public function __construct()
+    /**
+     * @param Filter|QueryModifier ...$children
+     */
+    public function __construct(...$children)
     {
-        // NEXT_MAJOR: use variable-length argument lists (...$children)
-        parent::__construct(self::AND_X, func_get_args());
+        parent::__construct(self::AND_X, ...$children);
     }
 
     /**

--- a/src/Logic/LogicX.php
+++ b/src/Logic/LogicX.php
@@ -29,22 +29,22 @@ abstract class LogicX implements Specification
     const OR_X = 'orX';
 
     /**
-     * @var Filter[]|QueryModifier[]
-     */
-    private $children;
-
-    /**
      * @var string
      */
     private $expression;
 
     /**
+     * @var Filter[]|QueryModifier[]
+     */
+    private $children;
+
+    /**
      * Take two or more Expression as parameters.
      *
-     * @param string                   $expression
-     * @param Filter[]|QueryModifier[] $children
+     * @param string               $expression
+     * @param Filter|QueryModifier ...$children
      */
-    public function __construct($expression, array $children = [])
+    public function __construct($expression, ...$children)
     {
         $this->expression = $expression;
         $this->children = $children;

--- a/src/Logic/OrX.php
+++ b/src/Logic/OrX.php
@@ -19,10 +19,12 @@ use Happyr\DoctrineSpecification\Query\QueryModifier;
 
 class OrX extends LogicX
 {
-    public function __construct()
+    /**
+     * @param Filter|QueryModifier ...$children
+     */
+    public function __construct(...$children)
     {
-        // NEXT_MAJOR: use variable-length argument lists (...$children)
-        parent::__construct(self::OR_X, func_get_args());
+        parent::__construct(self::OR_X, ...$children);
     }
 
     /**

--- a/src/Operand/PlatformFunction.php
+++ b/src/Operand/PlatformFunction.php
@@ -61,28 +61,21 @@ class PlatformFunction implements Operand
     /**
      * @var string
      */
-    private $functionName = '';
+    private $functionName;
 
     /**
-     * @var array
+     * @var mixed[]
      */
-    private $arguments = [];
+    private $arguments;
 
     /**
      * @param string $functionName
-     * @param mixed  $arguments
+     * @param mixed  ...$arguments
      */
-    public function __construct($functionName, $arguments = [])
+    public function __construct($functionName, ...$arguments)
     {
-        // NEXT_MAJOR: use variable-length argument lists ($functionName, ...$arguments)
-        if (2 === func_num_args()) {
-            $this->functionName = $functionName;
-            $this->arguments = (array) $arguments;
-        } else {
-            $arguments = func_get_args();
-            $this->functionName = array_shift($arguments);
-            $this->arguments = $arguments;
-        }
+        $this->functionName = $functionName;
+        $this->arguments = $arguments;
     }
 
     /**

--- a/src/Query/AbstractSelect.php
+++ b/src/Query/AbstractSelect.php
@@ -21,17 +21,16 @@ use Happyr\DoctrineSpecification\Query\Selection\Selection;
 abstract class AbstractSelect implements QueryModifier
 {
     /**
-     * @var Selection[]
+     * @var Selection[]|string[]
      */
     private $selections;
 
     /**
-     * @param mixed $field
+     * @param Selection|string ...$fields
      */
-    public function __construct($field)
+    public function __construct(...$fields)
     {
-        // NEXT_MAJOR: use variable-length argument lists (...$fields)
-        $this->selections = is_array($field) ? $field : func_get_args();
+        $this->selections = $fields;
     }
 
     /**

--- a/src/Query/QueryModifierCollection.php
+++ b/src/Query/QueryModifierCollection.php
@@ -26,11 +26,12 @@ class QueryModifierCollection implements QueryModifier
 
     /**
      * Construct it with one or more instances of QueryModifier.
+     *
+     * @param QueryModifier ...$children
      */
-    public function __construct()
+    public function __construct(...$children)
     {
-        // NEXT_MAJOR: use variable-length argument lists (...$children)
-        $this->children = func_get_args();
+        $this->children = $children;
     }
 
     /**

--- a/src/Result/ResultModifierCollection.php
+++ b/src/Result/ResultModifierCollection.php
@@ -26,11 +26,12 @@ class ResultModifierCollection implements ResultModifier
 
     /**
      * Construct it with one or more instances of ResultModifier.
+     *
+     * @param ResultModifier ...$children
      */
-    public function __construct()
+    public function __construct(...$children)
     {
-        // NEXT_MAJOR: use variable-length argument lists (...$children)
-        $this->children = func_get_args();
+        $this->children = $children;
     }
 
     /**

--- a/src/Spec.php
+++ b/src/Spec.php
@@ -59,6 +59,7 @@ use Happyr\DoctrineSpecification\Query\Select;
 use Happyr\DoctrineSpecification\Query\Selection\SelectAs;
 use Happyr\DoctrineSpecification\Query\Selection\SelectEntity;
 use Happyr\DoctrineSpecification\Query\Selection\SelectHiddenAs;
+use Happyr\DoctrineSpecification\Query\Selection\Selection;
 use Happyr\DoctrineSpecification\Query\Slice;
 use Happyr\DoctrineSpecification\Result\AsArray;
 use Happyr\DoctrineSpecification\Result\AsScalar;
@@ -99,60 +100,36 @@ use Happyr\DoctrineSpecification\Specification\CountOf;
 class Spec
 {
     /**
-     * @param string $name
-     * @param array  $arguments
+     * @param string  $functionName
+     * @param mixed[] $arguments
      *
      * @return PlatformFunction
      */
-    public static function __callStatic($name, array $arguments = [])
+    public static function __callStatic($functionName, array $arguments = [])
     {
-        // allow use array in arguments of static function
-        // Spec::DATE_DIFF([$date1, $date2]);
-        // is equal
-        // Spec::DATE_DIFF($date1, $date2);
-        if (1 === count($arguments) && is_array(current($arguments))) {
-            $arguments = current($arguments);
-        }
-
-        return self::fun($name, $arguments);
+        return self::fun($functionName, ...$arguments);
     }
 
     // Logic
 
     /**
+     * @param Filter|QueryModifier ...$specs
+     *
      * @return AndX
      */
-    public static function andX()
+    public static function andX(...$specs)
     {
-        // NEXT_MAJOR: use variable-length argument lists (...$specs)
-        $spec = (new \ReflectionClass(AndX::class))->newInstanceArgs(func_get_args());
-
-        // hook for PHPStan
-        if (!($spec instanceof AndX)) {
-            throw new \RuntimeException(
-                sprintf('The specification must be an instance of "%s", but got "%s".', AndX::class, get_class($spec))
-            );
-        }
-
-        return $spec;
+        return new AndX(...$specs);
     }
 
     /**
+     * @param Filter|QueryModifier ...$specs
+     *
      * @return OrX
      */
-    public static function orX()
+    public static function orX(...$specs)
     {
-        // NEXT_MAJOR: use variable-length argument lists (...$specs)
-        $spec = (new \ReflectionClass(OrX::class))->newInstanceArgs(func_get_args());
-
-        // hook for PHPStan
-        if (!($spec instanceof OrX)) {
-            throw new \RuntimeException(
-                sprintf('The specification must be an instance of "%s", but got "%s".', OrX::class, get_class($spec))
-            );
-        }
-
-        return $spec;
+        return new OrX(...$specs);
     }
 
     /**
@@ -279,25 +256,23 @@ class Spec
     // Selection
 
     /**
-     * @param mixed $field
+     * @param Selection|string ...$fields
      *
      * @return Select
      */
-    public static function select($field)
+    public static function select(...$fields)
     {
-        // NEXT_MAJOR: use variable-length argument lists (...$fields)
-        return new Select(func_get_args());
+        return new Select(...$fields);
     }
 
     /**
-     * @param mixed $field
+     * @param Selection|string ...$fields
      *
      * @return AddSelect
      */
-    public static function addSelect($field)
+    public static function addSelect(...$fields)
     {
-        // NEXT_MAJOR: use variable-length argument lists (...$fields)
-        return new AddSelect(func_get_args());
+        return new AddSelect(...$fields);
     }
 
     /**
@@ -677,24 +652,15 @@ class Spec
      * Usage:
      *  Spec::fun('CURRENT_DATE')
      *  Spec::fun('DATE_DIFF', $date1, $date2)
-     *  Spec::fun('DATE_DIFF', [$date1, $date2])
      *
      * @param string $functionName
-     * @param mixed  $arguments
+     * @param mixed  ...$arguments
      *
      * @return PlatformFunction
      */
-    public static function fun($functionName, $arguments = [])
+    public static function fun($functionName, ...$arguments)
     {
-        // NEXT_MAJOR: use variable-length argument lists ($functionName, ...$arguments)
-        if (2 === func_num_args()) {
-            $arguments = (array) $arguments;
-        } else {
-            $arguments = func_get_args();
-            $functionName = array_shift($arguments);
-        }
-
-        return new PlatformFunction($functionName, $arguments);
+        return new PlatformFunction($functionName, ...$arguments);
     }
 
     /**

--- a/tests/Operand/PlatformFunctionSpec.php
+++ b/tests/Operand/PlatformFunctionSpec.php
@@ -67,16 +67,6 @@ class PlatformFunctionSpec extends ObjectBehavior
         $this->transform($qb, $dqlAlias)->shouldReturn($expression);
     }
 
-    public function it_is_transformable_many_arguments_as_array(QueryBuilder $qb)
-    {
-        $dqlAlias = 'a';
-        $expression = 'concat(a.foo, a.bar)';
-
-        $this->beConstructedWith('concat', [new Field('foo'), new Field('bar')]);
-
-        $this->transform($qb, $dqlAlias)->shouldReturn($expression);
-    }
-
     public function it_is_transformable_custom_string_function(
         QueryBuilder $qb,
         EntityManagerInterface $em,
@@ -179,7 +169,7 @@ class PlatformFunctionSpec extends ObjectBehavior
 
         $value->transform($qb, $dqlAlias)->willReturn(':comparison_11');
 
-        $this->beConstructedWith($functionName, ['foo', 'bar', $value]);
+        $this->beConstructedWith($functionName, 'foo', 'bar', $value);
 
         $this->transform($qb, $dqlAlias)->shouldReturn($expression);
     }

--- a/tests/Query/AddSelectSpec.php
+++ b/tests/Query/AddSelectSpec.php
@@ -53,13 +53,6 @@ class AddSelectSpec extends ObjectBehavior
         $this->modify($qb, 'b');
     }
 
-    public function it_add_select_several_fields_as_array(QueryBuilder $qb)
-    {
-        $this->beConstructedWith(['foo', 'bar']);
-        $qb->addSelect(['b.foo', 'b.bar'])->shouldBeCalled();
-        $this->modify($qb, 'b');
-    }
-
     public function it_add_select_operand(QueryBuilder $qb)
     {
         $this->beConstructedWith('foo', new Field('bar'));

--- a/tests/Query/SelectSpec.php
+++ b/tests/Query/SelectSpec.php
@@ -53,13 +53,6 @@ class SelectSpec extends ObjectBehavior
         $this->modify($qb, 'b');
     }
 
-    public function it_select_several_fields_as_array(QueryBuilder $qb)
-    {
-        $this->beConstructedWith(['foo', 'bar']);
-        $qb->select(['b.foo', 'b.bar'])->shouldBeCalled();
-        $this->modify($qb, 'b');
-    }
-
     public function it_select_operand(QueryBuilder $qb)
     {
         $this->beConstructedWith('foo', new Field('bar'));


### PR DESCRIPTION
Use [variable-length argument lists](https://www.php.net/manual/en/functions.arguments.php#functions.variable-arg-list) in `AndX`, `OrX`, `Select`, `AddSelect`, `PlatformFunction`, `QueryModifierCollection` and `ResultModifierCollection`.

## Upgrade

* Removes the ability to use `array` as argument for the `PlatformFunction` operand.

  Before:

  ```php
  $arguments = ['create_at', new \DateTimeImmutable()];
  Spec::DATE_DIFF($arguments);
  Spec::fun('DATE_DIFF', $arguments);
  new PlatformFunction('DATE_DIFF', $arguments);
  ```

  After:

  ```php
  $arguments = ['create_at', new \DateTimeImmutable()];
  Spec::DATE_DIFF(...$arguments);
  Spec::fun('DATE_DIFF', ...$arguments);
  new PlatformFunction('DATE_DIFF', ...$arguments);
  ```

* Removes the ability to use `array` as argument for the `Select` query modifier.

  Before:

  ```php
  $fields = ['title', 'cover'];
  Spec::select($fields);
  new Select($fields);
  ```

  After:

  ```php
  $fields = ['title', 'cover'];
  Spec::select(...$fields);
  new Select(...$fields);
  ```

* Removes the ability to use `array` as argument for the `AddSelect` query modifier.

  Before:

  ```php
  $fields = ['title', 'cover'];
  Spec::addSelect($fields);
  new AddSelect($fields);
  ```

  After:

  ```php
  $fields = ['title', 'cover'];
  Spec::addSelect(...$fields);
  new AddSelect(...$fields);
  ```