### PR TITLE
Change access for exception classes

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -69,6 +69,11 @@
   ```
 
 * The `BaseSpecification::getSpec()` method marked as `abstract`.
+* The `InvalidArgumentException` class marked as `final`.
+* The `LogicException` class marked as `final`.
+* The `NonUniqueResultException` class marked as `final`.
+* The `NoResultException` class marked as `final`.
+* The `UnexpectedResultException` class marked as `abstract`.
 
 # Upgrade from 1.0 to 1.1
 

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -14,6 +14,6 @@ declare(strict_types=1);
 
 namespace Happyr\DoctrineSpecification\Exception;
 
-class InvalidArgumentException extends \InvalidArgumentException
+final class InvalidArgumentException extends \InvalidArgumentException
 {
 }

--- a/src/Exception/LogicException.php
+++ b/src/Exception/LogicException.php
@@ -14,6 +14,6 @@ declare(strict_types=1);
 
 namespace Happyr\DoctrineSpecification\Exception;
 
-class LogicException extends \LogicException
+final class LogicException extends \LogicException
 {
 }

--- a/src/Exception/NoResultException.php
+++ b/src/Exception/NoResultException.php
@@ -14,6 +14,6 @@ declare(strict_types=1);
 
 namespace Happyr\DoctrineSpecification\Exception;
 
-class NoResultException extends UnexpectedResultException
+final class NoResultException extends UnexpectedResultException
 {
 }

--- a/src/Exception/NonUniqueResultException.php
+++ b/src/Exception/NonUniqueResultException.php
@@ -14,6 +14,6 @@ declare(strict_types=1);
 
 namespace Happyr\DoctrineSpecification\Exception;
 
-class NonUniqueResultException extends UnexpectedResultException
+final class NonUniqueResultException extends UnexpectedResultException
 {
 }

--- a/src/Exception/UnexpectedResultException.php
+++ b/src/Exception/UnexpectedResultException.php
@@ -16,6 +16,6 @@ namespace Happyr\DoctrineSpecification\Exception;
 
 use RuntimeException;
 
-class UnexpectedResultException extends RuntimeException
+abstract class UnexpectedResultException extends RuntimeException
 {
 }


### PR DESCRIPTION
## Upgrade

* The `InvalidArgumentException` class marked as `final`.
* The `LogicException` class marked as `final`.
* The `NonUniqueResultException` class marked as `final`.
* The `NoResultException` class marked as `final`.
* The `UnexpectedResultException` class marked as `abstract`.