### PR TITLE
Pedantic fixes

### DIFF
--- a/src/EntitySpecificationRepositoryTrait.php
+++ b/src/EntitySpecificationRepositoryTrait.php
@@ -29,7 +29,7 @@ use Happyr\DoctrineSpecification\Result\ResultModifier;
 trait EntitySpecificationRepositoryTrait
 {
     /**
-     * @var string alias
+     * @var string
      */
     private $alias = 'e';
 

--- a/src/Exception/UnexpectedResultException.php
+++ b/src/Exception/UnexpectedResultException.php
@@ -14,8 +14,6 @@ declare(strict_types=1);
 
 namespace Happyr\DoctrineSpecification\Exception;
 
-use RuntimeException;
-
-abstract class UnexpectedResultException extends RuntimeException
+abstract class UnexpectedResultException extends \RuntimeException
 {
 }

--- a/src/Filter/MemberOfX.php
+++ b/src/Filter/MemberOfX.php
@@ -36,7 +36,7 @@ class MemberOfX implements Filter
     private $dqlAlias;
 
     /**
-     * @param Operand|string $value
+     * @param Operand|mixed  $value
      * @param Operand|string $field
      * @param string|null    $dqlAlias
      */

--- a/src/Logic/Not.php
+++ b/src/Logic/Not.php
@@ -22,7 +22,7 @@ use Happyr\DoctrineSpecification\Specification\Specification;
 class Not implements Specification
 {
     /**
-     * @var Filter child
+     * @var Filter
      */
     private $child;
 

--- a/src/Operand/Addition.php
+++ b/src/Operand/Addition.php
@@ -18,7 +18,7 @@ class Addition extends Arithmetic
 {
     /**
      * @param Operand|string $field
-     * @param Operand|string $value
+     * @param Operand|mixed  $value
      */
     public function __construct($field, $value)
     {

--- a/src/Operand/ArgumentToOperandConverter.php
+++ b/src/Operand/ArgumentToOperandConverter.php
@@ -78,7 +78,7 @@ class ArgumentToOperandConverter
      */
     public static function convert(array $arguments): array
     {
-        $result = [];
+        $operands = [];
         foreach (array_values($arguments) as $i => $argument) {
             // always try convert the first argument to the field operand
             if (0 === $i) {
@@ -87,9 +87,9 @@ class ArgumentToOperandConverter
                 $argument = self::toValue($argument);
             }
 
-            $result[] = $argument;
+            $operands[] = $argument;
         }
 
-        return $result;
+        return $operands;
     }
 }

--- a/src/Operand/Arithmetic.php
+++ b/src/Operand/Arithmetic.php
@@ -58,7 +58,7 @@ abstract class Arithmetic implements Operand
     /**
      * @param string         $operation
      * @param Operand|string $field
-     * @param Operand|string $value
+     * @param Operand|mixed  $value
      */
     public function __construct(string $operation, $field, $value)
     {

--- a/src/Operand/Division.php
+++ b/src/Operand/Division.php
@@ -18,7 +18,7 @@ class Division extends Arithmetic
 {
     /**
      * @param Operand|string $field
-     * @param Operand|string $value
+     * @param Operand|mixed  $value
      */
     public function __construct($field, $value)
     {

--- a/src/Operand/Modulo.php
+++ b/src/Operand/Modulo.php
@@ -18,7 +18,7 @@ class Modulo extends Arithmetic
 {
     /**
      * @param Operand|string $field
-     * @param Operand|string $value
+     * @param Operand|mixed  $value
      */
     public function __construct($field, $value)
     {

--- a/src/Operand/Multiplication.php
+++ b/src/Operand/Multiplication.php
@@ -18,7 +18,7 @@ class Multiplication extends Arithmetic
 {
     /**
      * @param Operand|string $field
-     * @param Operand|string $value
+     * @param Operand|mixed  $value
      */
     public function __construct($field, $value)
     {

--- a/src/Operand/Subtraction.php
+++ b/src/Operand/Subtraction.php
@@ -18,7 +18,7 @@ class Subtraction extends Arithmetic
 {
     /**
      * @param Operand|string $field
-     * @param Operand|string $value
+     * @param Operand|mixed  $value
      */
     public function __construct($field, $value)
     {

--- a/src/Query/AbstractJoin.php
+++ b/src/Query/AbstractJoin.php
@@ -16,9 +16,6 @@ namespace Happyr\DoctrineSpecification\Query;
 
 use Doctrine\ORM\QueryBuilder;
 
-/**
- * @author Tobias Nyholm
- */
 abstract class AbstractJoin implements QueryModifier
 {
     /**

--- a/src/Query/AbstractSelect.php
+++ b/src/Query/AbstractSelect.php
@@ -26,11 +26,11 @@ abstract class AbstractSelect implements QueryModifier
     private $selections;
 
     /**
-     * @param Selection|string ...$fields
+     * @param Selection|string ...$selections
      */
-    public function __construct(...$fields)
+    public function __construct(...$selections)
     {
-        $this->selections = $fields;
+        $this->selections = $selections;
     }
 
     /**

--- a/src/Query/OrderBy.php
+++ b/src/Query/OrderBy.php
@@ -20,6 +20,10 @@ use Happyr\DoctrineSpecification\Operand\Field;
 
 class OrderBy implements QueryModifier
 {
+    public const ASC = 'ASC';
+
+    public const DESC = 'DESC';
+
     /**
      * @var Field|Alias
      */
@@ -40,7 +44,7 @@ class OrderBy implements QueryModifier
      * @param string             $order
      * @param string|null        $dqlAlias
      */
-    public function __construct($field, string $order = 'ASC', ?string $dqlAlias = null)
+    public function __construct($field, string $order = self::ASC, ?string $dqlAlias = null)
     {
         if (!($field instanceof Field) && !($field instanceof Alias)) {
             $field = new Field($field);

--- a/src/Query/Selection/AbstractSelectAs.php
+++ b/src/Query/Selection/AbstractSelectAs.php
@@ -29,7 +29,7 @@ abstract class AbstractSelectAs implements Selection
     /**
      * @var string
      */
-    private $alias = '';
+    private $alias;
 
     /**
      * @param Filter|Operand|string $expression

--- a/src/Query/Selection/SelectEntity.php
+++ b/src/Query/Selection/SelectEntity.php
@@ -21,7 +21,7 @@ class SelectEntity implements Selection
     /**
      * @var string
      */
-    private $dqlAlias = '';
+    private $dqlAlias;
 
     /**
      * @param string $dqlAlias

--- a/src/Result/AsArray.php
+++ b/src/Result/AsArray.php
@@ -17,9 +17,6 @@ namespace Happyr\DoctrineSpecification\Result;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\Query;
 
-/**
- * Class AsArray.
- */
 class AsArray implements ResultModifier
 {
     /**

--- a/src/Result/AsScalar.php
+++ b/src/Result/AsScalar.php
@@ -17,9 +17,6 @@ namespace Happyr\DoctrineSpecification\Result;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\Query;
 
-/**
- * Class AsScalar.
- */
 class AsScalar implements ResultModifier
 {
     /**

--- a/src/Result/AsSingleScalar.php
+++ b/src/Result/AsSingleScalar.php
@@ -17,9 +17,6 @@ namespace Happyr\DoctrineSpecification\Result;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\Query;
 
-/**
- * Class AsSingleScalar.
- */
 class AsSingleScalar implements ResultModifier
 {
     /**

--- a/src/Result/RoundDateTime.php
+++ b/src/Result/RoundDateTime.php
@@ -15,10 +15,9 @@ declare(strict_types=1);
 namespace Happyr\DoctrineSpecification\Result;
 
 use Doctrine\ORM\AbstractQuery;
-use Doctrine\ORM\Query\Parameter;
 
 /**
- * Round a \DateTime to enable caching.
+ * Round a \DateTime and \DateTimeImmutable to enable caching.
  */
 class RoundDateTime implements ResultModifier
 {
@@ -41,10 +40,9 @@ class RoundDateTime implements ResultModifier
     public function modify(AbstractQuery $query): void
     {
         foreach ($query->getParameters() as $parameter) {
-            if ($parameter instanceof Parameter &&
-                ($value = $parameter->getValue()) &&
-                $value instanceof \DateTimeInterface
-            ) {
+            $value = $parameter->getValue();
+
+            if ($value instanceof \DateTimeInterface) {
                 // round down so that the results do not include data that should not be there.
                 $uts = (int) (floor($value->getTimestamp() / $this->roundSeconds) * $this->roundSeconds);
                 $date = (new \DateTimeImmutable('now', $value->getTimezone()))->setTimestamp($uts);

--- a/src/Spec.php
+++ b/src/Spec.php
@@ -499,7 +499,7 @@ class Spec
     }
 
     /**
-     * @param Operand|string $value
+     * @param Operand|mixed  $value
      * @param Operand|string $field
      * @param string|null    $dqlAlias
      *

--- a/src/Specification/CountOf.php
+++ b/src/Specification/CountOf.php
@@ -18,13 +18,10 @@ use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Filter\Filter;
 use Happyr\DoctrineSpecification\Query\QueryModifier;
 
-/**
- * @author Tobias Nyholm
- */
 class CountOf implements Specification
 {
     /**
-     * @var Filter|QueryModifier child
+     * @var Filter|QueryModifier
      */
     private $child;
 


### PR DESCRIPTION
* Fix typo in annotations;
* Add `ASC` and `DESC` constants in `OrderBy` spec;
* Rename some variables;
* Don't check that `$query->getParameters()` instance of `Parameter`. This is always true for Doctrine ORM `>= 2.3`