### PR TITLE
Prefer composition over inheritance

### DIFF
--- a/src/Filter/Equals.php
+++ b/src/Filter/Equals.php
@@ -16,7 +16,7 @@ namespace Happyr\DoctrineSpecification\Filter;
 
 use Happyr\DoctrineSpecification\Operand\Operand;
 
-class Equals extends Comparison
+final class Equals extends Comparison
 {
     /**
      * @param Operand|string $field

--- a/src/Filter/GreaterOrEqualThan.php
+++ b/src/Filter/GreaterOrEqualThan.php
@@ -16,7 +16,7 @@ namespace Happyr\DoctrineSpecification\Filter;
 
 use Happyr\DoctrineSpecification\Operand\Operand;
 
-class GreaterOrEqualThan extends Comparison
+final class GreaterOrEqualThan extends Comparison
 {
     /**
      * @param Operand|string $field

--- a/src/Filter/GreaterThan.php
+++ b/src/Filter/GreaterThan.php
@@ -16,7 +16,7 @@ namespace Happyr\DoctrineSpecification\Filter;
 
 use Happyr\DoctrineSpecification\Operand\Operand;
 
-class GreaterThan extends Comparison
+final class GreaterThan extends Comparison
 {
     /**
      * @param Operand|string $field

--- a/src/Filter/In.php
+++ b/src/Filter/In.php
@@ -18,7 +18,7 @@ use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Operand\ArgumentToOperandConverter;
 use Happyr\DoctrineSpecification\Operand\Operand;
 
-class In implements Filter
+final class In implements Filter
 {
     /**
      * @var Operand|string

--- a/src/Filter/InstanceOfX.php
+++ b/src/Filter/InstanceOfX.php
@@ -16,7 +16,7 @@ namespace Happyr\DoctrineSpecification\Filter;
 
 use Doctrine\ORM\QueryBuilder;
 
-class InstanceOfX implements Filter
+final class InstanceOfX implements Filter
 {
     /**
      * @var string

--- a/src/Filter/IsNotNull.php
+++ b/src/Filter/IsNotNull.php
@@ -18,7 +18,7 @@ use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Operand\ArgumentToOperandConverter;
 use Happyr\DoctrineSpecification\Operand\Operand;
 
-class IsNotNull implements Filter
+final class IsNotNull implements Filter
 {
     /**
      * @var Operand|string

--- a/src/Filter/IsNull.php
+++ b/src/Filter/IsNull.php
@@ -18,7 +18,7 @@ use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Operand\ArgumentToOperandConverter;
 use Happyr\DoctrineSpecification\Operand\Operand;
 
-class IsNull implements Filter
+final class IsNull implements Filter
 {
     /**
      * @var Operand|string

--- a/src/Filter/LessOrEqualThan.php
+++ b/src/Filter/LessOrEqualThan.php
@@ -16,7 +16,7 @@ namespace Happyr\DoctrineSpecification\Filter;
 
 use Happyr\DoctrineSpecification\Operand\Operand;
 
-class LessOrEqualThan extends Comparison
+final class LessOrEqualThan extends Comparison
 {
     /**
      * @param Operand|string $field

--- a/src/Filter/LessThan.php
+++ b/src/Filter/LessThan.php
@@ -16,7 +16,7 @@ namespace Happyr\DoctrineSpecification\Filter;
 
 use Happyr\DoctrineSpecification\Operand\Operand;
 
-class LessThan extends Comparison
+final class LessThan extends Comparison
 {
     /**
      * @param Operand|string $field

--- a/src/Filter/Like.php
+++ b/src/Filter/Like.php
@@ -20,7 +20,7 @@ use Happyr\DoctrineSpecification\Operand\ArgumentToOperandConverter;
 use Happyr\DoctrineSpecification\Operand\LikePattern;
 use Happyr\DoctrineSpecification\Operand\Operand;
 
-class Like implements Filter
+final class Like implements Filter
 {
     public const CONTAINS = LikePattern::CONTAINS;
 

--- a/src/Filter/MemberOfX.php
+++ b/src/Filter/MemberOfX.php
@@ -18,7 +18,7 @@ use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Operand\ArgumentToOperandConverter;
 use Happyr\DoctrineSpecification\Operand\Operand;
 
-class MemberOfX implements Filter
+final class MemberOfX implements Filter
 {
     /**
      * @var Operand|string

--- a/src/Filter/NotEquals.php
+++ b/src/Filter/NotEquals.php
@@ -16,7 +16,7 @@ namespace Happyr\DoctrineSpecification\Filter;
 
 use Happyr\DoctrineSpecification\Operand\Operand;
 
-class NotEquals extends Comparison
+final class NotEquals extends Comparison
 {
     /**
      * @param Operand|string $field

--- a/src/Logic/AndX.php
+++ b/src/Logic/AndX.php
@@ -17,7 +17,7 @@ namespace Happyr\DoctrineSpecification\Logic;
 use Happyr\DoctrineSpecification\Filter\Filter;
 use Happyr\DoctrineSpecification\Query\QueryModifier;
 
-class AndX extends LogicX
+final class AndX extends LogicX
 {
     /**
      * @param Filter|QueryModifier ...$children

--- a/src/Logic/Not.php
+++ b/src/Logic/Not.php
@@ -19,7 +19,7 @@ use Happyr\DoctrineSpecification\Filter\Filter;
 use Happyr\DoctrineSpecification\Query\QueryModifier;
 use Happyr\DoctrineSpecification\Specification\Specification;
 
-class Not implements Specification
+final class Not implements Specification
 {
     /**
      * @var Filter

--- a/src/Logic/OrX.php
+++ b/src/Logic/OrX.php
@@ -17,7 +17,7 @@ namespace Happyr\DoctrineSpecification\Logic;
 use Happyr\DoctrineSpecification\Filter\Filter;
 use Happyr\DoctrineSpecification\Query\QueryModifier;
 
-class OrX extends LogicX
+final class OrX extends LogicX
 {
     /**
      * @param Filter|QueryModifier ...$children

--- a/src/Operand/Addition.php
+++ b/src/Operand/Addition.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 
 namespace Happyr\DoctrineSpecification\Operand;
 
-class Addition extends Arithmetic
+final class Addition extends Arithmetic
 {
     /**
      * @param Operand|string $field

--- a/src/Operand/Alias.php
+++ b/src/Operand/Alias.php
@@ -16,7 +16,7 @@ namespace Happyr\DoctrineSpecification\Operand;
 
 use Doctrine\ORM\QueryBuilder;
 
-class Alias implements Operand
+final class Alias implements Operand
 {
     /**
      * @var string

--- a/src/Operand/ArgumentToOperandConverter.php
+++ b/src/Operand/ArgumentToOperandConverter.php
@@ -17,7 +17,7 @@ namespace Happyr\DoctrineSpecification\Operand;
 /**
  * This service is intended for backward compatibility and may be removed in the future.
  */
-class ArgumentToOperandConverter
+final class ArgumentToOperandConverter
 {
     /**
      * Convert the argument into the field operand if it is not an operand.

--- a/src/Operand/CountDistinct.php
+++ b/src/Operand/CountDistinct.php
@@ -16,7 +16,7 @@ namespace Happyr\DoctrineSpecification\Operand;
 
 use Doctrine\ORM\QueryBuilder;
 
-class CountDistinct implements Operand
+final class CountDistinct implements Operand
 {
     /**
      * @var Operand|string

--- a/src/Operand/Division.php
+++ b/src/Operand/Division.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 
 namespace Happyr\DoctrineSpecification\Operand;
 
-class Division extends Arithmetic
+final class Division extends Arithmetic
 {
     /**
      * @param Operand|string $field

--- a/src/Operand/Field.php
+++ b/src/Operand/Field.php
@@ -17,7 +17,7 @@ namespace Happyr\DoctrineSpecification\Operand;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Query\Selection\Selection;
 
-class Field implements Operand, Selection
+final class Field implements Operand, Selection
 {
     /**
      * @var string

--- a/src/Operand/LikePattern.php
+++ b/src/Operand/LikePattern.php
@@ -17,7 +17,7 @@ namespace Happyr\DoctrineSpecification\Operand;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\ValueConverter;
 
-class LikePattern implements Operand
+final class LikePattern implements Operand
 {
     public const CONTAINS = '%%%s%%';
 

--- a/src/Operand/Modulo.php
+++ b/src/Operand/Modulo.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 
 namespace Happyr\DoctrineSpecification\Operand;
 
-class Modulo extends Arithmetic
+final class Modulo extends Arithmetic
 {
     /**
      * @param Operand|string $field

--- a/src/Operand/Multiplication.php
+++ b/src/Operand/Multiplication.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 
 namespace Happyr\DoctrineSpecification\Operand;
 
-class Multiplication extends Arithmetic
+final class Multiplication extends Arithmetic
 {
     /**
      * @param Operand|string $field

--- a/src/Operand/PlatformFunction.php
+++ b/src/Operand/PlatformFunction.php
@@ -17,7 +17,7 @@ namespace Happyr\DoctrineSpecification\Operand;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Exception\InvalidArgumentException;
 
-class PlatformFunction implements Operand
+final class PlatformFunction implements Operand
 {
     /**
      * Doctrine internal functions.

--- a/src/Operand/Subtraction.php
+++ b/src/Operand/Subtraction.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 
 namespace Happyr\DoctrineSpecification\Operand;
 
-class Subtraction extends Arithmetic
+final class Subtraction extends Arithmetic
 {
     /**
      * @param Operand|string $field

--- a/src/Operand/Value.php
+++ b/src/Operand/Value.php
@@ -17,7 +17,7 @@ namespace Happyr\DoctrineSpecification\Operand;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\ValueConverter;
 
-class Value implements Operand
+final class Value implements Operand
 {
     /**
      * @var mixed

--- a/src/Operand/Values.php
+++ b/src/Operand/Values.php
@@ -17,7 +17,7 @@ namespace Happyr\DoctrineSpecification\Operand;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\ValueConverter;
 
-class Values implements Operand
+final class Values implements Operand
 {
     /**
      * @var mixed[]

--- a/src/Query/AddSelect.php
+++ b/src/Query/AddSelect.php
@@ -16,7 +16,7 @@ namespace Happyr\DoctrineSpecification\Query;
 
 use Doctrine\ORM\QueryBuilder;
 
-class AddSelect extends AbstractSelect
+final class AddSelect extends AbstractSelect
 {
     /**
      * @param QueryBuilder $qb

--- a/src/Query/Distinct.php
+++ b/src/Query/Distinct.php
@@ -16,7 +16,7 @@ namespace Happyr\DoctrineSpecification\Query;
 
 use Doctrine\ORM\QueryBuilder;
 
-class Distinct implements QueryModifier
+final class Distinct implements QueryModifier
 {
     /**
      * @param QueryBuilder $qb

--- a/src/Query/GroupBy.php
+++ b/src/Query/GroupBy.php
@@ -18,7 +18,7 @@ use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Operand\Alias;
 use Happyr\DoctrineSpecification\Operand\Field;
 
-class GroupBy implements QueryModifier
+final class GroupBy implements QueryModifier
 {
     /**
      * @var Field|Alias

--- a/src/Query/Having.php
+++ b/src/Query/Having.php
@@ -17,7 +17,7 @@ namespace Happyr\DoctrineSpecification\Query;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Filter\Filter;
 
-class Having implements QueryModifier
+final class Having implements QueryModifier
 {
     /**
      * @var Filter

--- a/src/Query/IndexBy.php
+++ b/src/Query/IndexBy.php
@@ -21,7 +21,7 @@ use Happyr\DoctrineSpecification\Operand\Field;
 /**
  * Class IndexBy.
  */
-class IndexBy implements QueryModifier
+final class IndexBy implements QueryModifier
 {
     /**
      * @var Field

--- a/src/Query/InnerJoin.php
+++ b/src/Query/InnerJoin.php
@@ -16,7 +16,7 @@ namespace Happyr\DoctrineSpecification\Query;
 
 use Doctrine\ORM\QueryBuilder;
 
-class InnerJoin extends AbstractJoin
+final class InnerJoin extends AbstractJoin
 {
     /**
      * {@inheritdoc}

--- a/src/Query/Join.php
+++ b/src/Query/Join.php
@@ -16,7 +16,7 @@ namespace Happyr\DoctrineSpecification\Query;
 
 use Doctrine\ORM\QueryBuilder;
 
-class Join extends AbstractJoin
+final class Join extends AbstractJoin
 {
     /**
      * {@inheritdoc}

--- a/src/Query/LeftJoin.php
+++ b/src/Query/LeftJoin.php
@@ -16,7 +16,7 @@ namespace Happyr\DoctrineSpecification\Query;
 
 use Doctrine\ORM\QueryBuilder;
 
-class LeftJoin extends AbstractJoin
+final class LeftJoin extends AbstractJoin
 {
     /**
      * {@inheritdoc}

--- a/src/Query/Limit.php
+++ b/src/Query/Limit.php
@@ -16,7 +16,7 @@ namespace Happyr\DoctrineSpecification\Query;
 
 use Doctrine\ORM\QueryBuilder;
 
-class Limit implements QueryModifier
+final class Limit implements QueryModifier
 {
     /**
      * @var int limit

--- a/src/Query/Offset.php
+++ b/src/Query/Offset.php
@@ -16,7 +16,7 @@ namespace Happyr\DoctrineSpecification\Query;
 
 use Doctrine\ORM\QueryBuilder;
 
-class Offset implements QueryModifier
+final class Offset implements QueryModifier
 {
     /**
      * @var int

--- a/src/Query/OrderBy.php
+++ b/src/Query/OrderBy.php
@@ -18,7 +18,7 @@ use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Operand\Alias;
 use Happyr\DoctrineSpecification\Operand\Field;
 
-class OrderBy implements QueryModifier
+final class OrderBy implements QueryModifier
 {
     public const ASC = 'ASC';
 

--- a/src/Query/QueryModifierCollection.php
+++ b/src/Query/QueryModifierCollection.php
@@ -17,7 +17,7 @@ namespace Happyr\DoctrineSpecification\Query;
 use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Exception\InvalidArgumentException;
 
-class QueryModifierCollection implements QueryModifier
+final class QueryModifierCollection implements QueryModifier
 {
     /**
      * @var QueryModifier[]

--- a/src/Query/Select.php
+++ b/src/Query/Select.php
@@ -16,7 +16,7 @@ namespace Happyr\DoctrineSpecification\Query;
 
 use Doctrine\ORM\QueryBuilder;
 
-class Select extends AbstractSelect
+final class Select extends AbstractSelect
 {
     /**
      * @param QueryBuilder $qb

--- a/src/Query/Selection/ArgumentToSelectionConverter.php
+++ b/src/Query/Selection/ArgumentToSelectionConverter.php
@@ -19,7 +19,7 @@ use Happyr\DoctrineSpecification\Operand\Field;
 /**
  * This service is intended for backward compatibility and may be removed in the future.
  */
-class ArgumentToSelectionConverter
+final class ArgumentToSelectionConverter
 {
     /**
      * Convert the argument into the field operand if it is not an selection.

--- a/src/Query/Selection/SelectAs.php
+++ b/src/Query/Selection/SelectAs.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 
 namespace Happyr\DoctrineSpecification\Query\Selection;
 
-class SelectAs extends AbstractSelectAs
+final class SelectAs extends AbstractSelectAs
 {
     /**
      * @return string

--- a/src/Query/Selection/SelectEntity.php
+++ b/src/Query/Selection/SelectEntity.php
@@ -16,7 +16,7 @@ namespace Happyr\DoctrineSpecification\Query\Selection;
 
 use Doctrine\ORM\QueryBuilder;
 
-class SelectEntity implements Selection
+final class SelectEntity implements Selection
 {
     /**
      * @var string

--- a/src/Query/Selection/SelectHiddenAs.php
+++ b/src/Query/Selection/SelectHiddenAs.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 
 namespace Happyr\DoctrineSpecification\Query\Selection;
 
-class SelectHiddenAs extends AbstractSelectAs
+final class SelectHiddenAs extends AbstractSelectAs
 {
     /**
      * @return string

--- a/src/Query/Slice.php
+++ b/src/Query/Slice.php
@@ -16,7 +16,7 @@ namespace Happyr\DoctrineSpecification\Query;
 
 use Doctrine\ORM\QueryBuilder;
 
-class Slice implements QueryModifier
+final class Slice implements QueryModifier
 {
     /**
      * @var int

--- a/src/Result/AsArray.php
+++ b/src/Result/AsArray.php
@@ -17,7 +17,7 @@ namespace Happyr\DoctrineSpecification\Result;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\Query;
 
-class AsArray implements ResultModifier
+final class AsArray implements ResultModifier
 {
     /**
      * @param AbstractQuery $query

--- a/src/Result/AsScalar.php
+++ b/src/Result/AsScalar.php
@@ -17,7 +17,7 @@ namespace Happyr\DoctrineSpecification\Result;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\Query;
 
-class AsScalar implements ResultModifier
+final class AsScalar implements ResultModifier
 {
     /**
      * @param AbstractQuery $query

--- a/src/Result/AsSingleScalar.php
+++ b/src/Result/AsSingleScalar.php
@@ -17,7 +17,7 @@ namespace Happyr\DoctrineSpecification\Result;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\Query;
 
-class AsSingleScalar implements ResultModifier
+final class AsSingleScalar implements ResultModifier
 {
     /**
      * @param AbstractQuery $query

--- a/src/Result/Cache.php
+++ b/src/Result/Cache.php
@@ -16,7 +16,7 @@ namespace Happyr\DoctrineSpecification\Result;
 
 use Doctrine\ORM\AbstractQuery;
 
-class Cache implements ResultModifier
+final class Cache implements ResultModifier
 {
     /**
      * @var int How may seconds the cache entry is valid

--- a/src/Result/ResultModifierCollection.php
+++ b/src/Result/ResultModifierCollection.php
@@ -17,7 +17,7 @@ namespace Happyr\DoctrineSpecification\Result;
 use Doctrine\ORM\AbstractQuery;
 use Happyr\DoctrineSpecification\Exception\InvalidArgumentException;
 
-class ResultModifierCollection implements ResultModifier
+final class ResultModifierCollection implements ResultModifier
 {
     /**
      * @var ResultModifier[]

--- a/src/Result/RoundDateTime.php
+++ b/src/Result/RoundDateTime.php
@@ -19,7 +19,7 @@ use Doctrine\ORM\AbstractQuery;
 /**
  * Round a \DateTime and \DateTimeImmutable to enable caching.
  */
-class RoundDateTime implements ResultModifier
+final class RoundDateTime implements ResultModifier
 {
     /**
      * @var int How may seconds to round time

--- a/src/Specification/CountOf.php
+++ b/src/Specification/CountOf.php
@@ -18,7 +18,7 @@ use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Filter\Filter;
 use Happyr\DoctrineSpecification\Query\QueryModifier;
 
-class CountOf implements Specification
+final class CountOf implements Specification
 {
     /**
      * @var Filter|QueryModifier

--- a/tests/EntitySpecificationRepositorySpec.php
+++ b/tests/EntitySpecificationRepositorySpec.php
@@ -34,7 +34,7 @@ use Prophecy\Argument;
 /**
  * @mixin EntitySpecificationRepository
  */
-class EntitySpecificationRepositorySpec extends ObjectBehavior
+final class EntitySpecificationRepositorySpec extends ObjectBehavior
 {
     private $alias = 'e';
 

--- a/tests/Filter/EqualsSpec.php
+++ b/tests/Filter/EqualsSpec.php
@@ -23,7 +23,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin Equals
  */
-class EqualsSpec extends ObjectBehavior
+final class EqualsSpec extends ObjectBehavior
 {
     public function let(): void
     {

--- a/tests/Filter/GreaterOrEqualThanSpec.php
+++ b/tests/Filter/GreaterOrEqualThanSpec.php
@@ -23,7 +23,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin GreaterOrEqualThan
  */
-class GreaterOrEqualThanSpec extends ObjectBehavior
+final class GreaterOrEqualThanSpec extends ObjectBehavior
 {
     public function let(): void
     {

--- a/tests/Filter/GreaterThanSpec.php
+++ b/tests/Filter/GreaterThanSpec.php
@@ -23,7 +23,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin GreaterThan
  */
-class GreaterThanSpec extends ObjectBehavior
+final class GreaterThanSpec extends ObjectBehavior
 {
     public function let(): void
     {

--- a/tests/Filter/InSpec.php
+++ b/tests/Filter/InSpec.php
@@ -24,7 +24,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin In
  */
-class InSpec extends ObjectBehavior
+final class InSpec extends ObjectBehavior
 {
     private $field = 'foobar';
 

--- a/tests/Filter/InstanceOfXSpec.php
+++ b/tests/Filter/InstanceOfXSpec.php
@@ -24,7 +24,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin InstanceOfX
  */
-class InstanceOfXSpec extends ObjectBehavior
+final class InstanceOfXSpec extends ObjectBehavior
 {
     public function let(): void
     {

--- a/tests/Filter/IsNotNullSpec.php
+++ b/tests/Filter/IsNotNullSpec.php
@@ -23,7 +23,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin IsNotNull
  */
-class IsNotNullSpec extends ObjectBehavior
+final class IsNotNullSpec extends ObjectBehavior
 {
     private $field = 'foobar';
 

--- a/tests/Filter/IsNullSpec.php
+++ b/tests/Filter/IsNullSpec.php
@@ -23,7 +23,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin IsNull
  */
-class IsNullSpec extends ObjectBehavior
+final class IsNullSpec extends ObjectBehavior
 {
     private $field = 'foobar';
 

--- a/tests/Filter/LessOrEqualThanSpec.php
+++ b/tests/Filter/LessOrEqualThanSpec.php
@@ -23,7 +23,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin LessOrEqualThan
  */
-class LessOrEqualThanSpec extends ObjectBehavior
+final class LessOrEqualThanSpec extends ObjectBehavior
 {
     public function let(): void
     {

--- a/tests/Filter/LessThanSpec.php
+++ b/tests/Filter/LessThanSpec.php
@@ -23,7 +23,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin LessThan
  */
-class LessThanSpec extends ObjectBehavior
+final class LessThanSpec extends ObjectBehavior
 {
     public function let(): void
     {

--- a/tests/Filter/LikeSpec.php
+++ b/tests/Filter/LikeSpec.php
@@ -20,7 +20,7 @@ use Happyr\DoctrineSpecification\Filter\Like;
 use Happyr\DoctrineSpecification\Specification\Specification;
 use PhpSpec\ObjectBehavior;
 
-class LikeSpec extends ObjectBehavior
+final class LikeSpec extends ObjectBehavior
 {
     private $field = 'foo';
 

--- a/tests/Filter/MemberOfXSpec.php
+++ b/tests/Filter/MemberOfXSpec.php
@@ -25,7 +25,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin MemberOfX
  */
-class MemberOfXSpec extends ObjectBehavior
+final class MemberOfXSpec extends ObjectBehavior
 {
     public function let(): void
     {

--- a/tests/Filter/NotEqualsSpec.php
+++ b/tests/Filter/NotEqualsSpec.php
@@ -23,7 +23,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin NotEquals
  */
-class NotEqualsSpec extends ObjectBehavior
+final class NotEqualsSpec extends ObjectBehavior
 {
     public function let(): void
     {

--- a/tests/Filter/SliceSpec.php
+++ b/tests/Filter/SliceSpec.php
@@ -22,7 +22,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin Slice
  */
-class SliceSpec extends ObjectBehavior
+final class SliceSpec extends ObjectBehavior
 {
     /**
      * @var int

--- a/tests/Logic/AndXSpec.php
+++ b/tests/Logic/AndXSpec.php
@@ -24,7 +24,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin AndX
  */
-class AndXSpec extends ObjectBehavior
+final class AndXSpec extends ObjectBehavior
 {
     public function let(Specification $specificationA, Specification $specificationB): void
     {

--- a/tests/Logic/NotSpec.php
+++ b/tests/Logic/NotSpec.php
@@ -24,7 +24,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin Not
  */
-class NotSpec extends ObjectBehavior
+final class NotSpec extends ObjectBehavior
 {
     public function let(Filter $filterExpr): void
     {

--- a/tests/Logic/OrXSpec.php
+++ b/tests/Logic/OrXSpec.php
@@ -24,7 +24,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin OrX
  */
-class OrXSpec extends ObjectBehavior
+final class OrXSpec extends ObjectBehavior
 {
     public function let(Specification $specificationA, Specification $specificationB): void
     {

--- a/tests/Operand/AdditionSpec.php
+++ b/tests/Operand/AdditionSpec.php
@@ -24,7 +24,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin Addition
  */
-class AdditionSpec extends ObjectBehavior
+final class AdditionSpec extends ObjectBehavior
 {
     private $field = 'foo';
 

--- a/tests/Operand/AliasSpec.php
+++ b/tests/Operand/AliasSpec.php
@@ -22,7 +22,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin Alias
  */
-class AliasSpec extends ObjectBehavior
+final class AliasSpec extends ObjectBehavior
 {
     private $alias = 'foo';
 

--- a/tests/Operand/ArgumentToOperandConverterSpec.php
+++ b/tests/Operand/ArgumentToOperandConverterSpec.php
@@ -23,7 +23,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin ArgumentToOperandConverter
  */
-class ArgumentToOperandConverterSpec extends ObjectBehavior
+final class ArgumentToOperandConverterSpec extends ObjectBehavior
 {
     public function it_is_a_converter(): void
     {
@@ -114,9 +114,9 @@ class ArgumentToOperandConverterSpec extends ObjectBehavior
         $subject->shouldHaveOperandAt(2);
     }
 
-    public function it_a_convertible_arguments2(Field $field, Operand $operand, Value $value): void
+    public function it_a_convertible_arguments2(Operand $operand): void
     {
-        $subject = $this->convert([$field, $operand, 'foo', $value]);
+        $subject = $this->convert([new Field('foo'), $operand, 'bar', new Value('baz')]);
         $subject->shouldBeArray();
         $subject->shouldHaveCount(4);
         $subject->shouldHaveField();

--- a/tests/Operand/CountDistinctSpec.php
+++ b/tests/Operand/CountDistinctSpec.php
@@ -22,7 +22,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin CountDistinct
  */
-class CountDistinctSpec extends ObjectBehavior
+final class CountDistinctSpec extends ObjectBehavior
 {
     private $field = 'foo';
 

--- a/tests/Operand/DivisionSpec.php
+++ b/tests/Operand/DivisionSpec.php
@@ -24,7 +24,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin Division
  */
-class DivisionSpec extends ObjectBehavior
+final class DivisionSpec extends ObjectBehavior
 {
     private $field = 'foo';
 

--- a/tests/Operand/FieldSpec.php
+++ b/tests/Operand/FieldSpec.php
@@ -22,7 +22,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin Field
  */
-class FieldSpec extends ObjectBehavior
+final class FieldSpec extends ObjectBehavior
 {
     private $fieldName = 'foo';
 

--- a/tests/Operand/LikePatternSpec.php
+++ b/tests/Operand/LikePatternSpec.php
@@ -23,7 +23,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin LikePattern
  */
-class LikePatternSpec extends ObjectBehavior
+final class LikePatternSpec extends ObjectBehavior
 {
     private $value = 'foo';
 

--- a/tests/Operand/ModuloSpec.php
+++ b/tests/Operand/ModuloSpec.php
@@ -24,7 +24,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin Modulo
  */
-class ModuloSpec extends ObjectBehavior
+final class ModuloSpec extends ObjectBehavior
 {
     private $field = 'foo';
 

--- a/tests/Operand/MultiplicationSpec.php
+++ b/tests/Operand/MultiplicationSpec.php
@@ -24,7 +24,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin Multiplication
  */
-class MultiplicationSpec extends ObjectBehavior
+final class MultiplicationSpec extends ObjectBehavior
 {
     private $field = 'foo';
 

--- a/tests/Operand/PlatformFunctionSpec.php
+++ b/tests/Operand/PlatformFunctionSpec.php
@@ -28,7 +28,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin PlatformFunction
  */
-class PlatformFunctionSpec extends ObjectBehavior
+final class PlatformFunctionSpec extends ObjectBehavior
 {
     private $functionName = 'UPPER';
 
@@ -148,18 +148,18 @@ class PlatformFunctionSpec extends ObjectBehavior
         QueryBuilder $qb,
         EntityManagerInterface $em,
         Configuration $configuration,
-        ArrayCollection $parameters,
-        Value $value
+        ArrayCollection $parameters
     ): void {
         $dqlAlias = 'a';
         $functionName = 'concat';
         $expression = 'concat(a.foo, :comparison_10, :comparison_11)';
 
-        $parameters->count()->willReturn(10);
+        $parameters->count()->willReturn(10, 11);
 
         $qb->getEntityManager()->willReturn($em);
         $qb->getParameters()->willReturn($parameters);
         $qb->setParameter('comparison_10', 'bar', null)->shouldBeCalled();
+        $qb->setParameter('comparison_11', 'baz', null)->shouldBeCalled();
 
         $em->getConfiguration()->willReturn($configuration);
 
@@ -167,7 +167,7 @@ class PlatformFunctionSpec extends ObjectBehavior
         $configuration->getCustomNumericFunction($functionName)->willReturn(null);
         $configuration->getCustomDatetimeFunction($functionName)->willReturn(null);
 
-        $value->transform($qb, $dqlAlias)->willReturn(':comparison_11');
+        $value = new Value('baz');
 
         $this->beConstructedWith($functionName, 'foo', 'bar', $value);
 

--- a/tests/Operand/SubtractionSpec.php
+++ b/tests/Operand/SubtractionSpec.php
@@ -24,7 +24,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin Subtraction
  */
-class SubtractionSpec extends ObjectBehavior
+final class SubtractionSpec extends ObjectBehavior
 {
     private $field = 'foo';
 

--- a/tests/Operand/ValueSpec.php
+++ b/tests/Operand/ValueSpec.php
@@ -24,7 +24,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin Value
  */
-class ValueSpec extends ObjectBehavior
+final class ValueSpec extends ObjectBehavior
 {
     private $value = 'foo';
 

--- a/tests/Operand/ValuesSpec.php
+++ b/tests/Operand/ValuesSpec.php
@@ -24,7 +24,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin Values
  */
-class ValuesSpec extends ObjectBehavior
+final class ValuesSpec extends ObjectBehavior
 {
     private $values = ['foo', 'bar'];
 

--- a/tests/Query/AddSelectSpec.php
+++ b/tests/Query/AddSelectSpec.php
@@ -23,7 +23,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin AddSelect
  */
-class AddSelectSpec extends ObjectBehavior
+final class AddSelectSpec extends ObjectBehavior
 {
     public function let(): void
     {

--- a/tests/Query/DistinctSpec.php
+++ b/tests/Query/DistinctSpec.php
@@ -22,7 +22,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin Distinct
  */
-class DistinctSpec extends ObjectBehavior
+final class DistinctSpec extends ObjectBehavior
 {
     public function it_is_a_distinct(): void
     {

--- a/tests/Query/HavingSpec.php
+++ b/tests/Query/HavingSpec.php
@@ -23,7 +23,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin Having
  */
-class HavingSpec extends ObjectBehavior
+final class HavingSpec extends ObjectBehavior
 {
     public function let(Filter $filter): void
     {

--- a/tests/Query/IndexBySpec.php
+++ b/tests/Query/IndexBySpec.php
@@ -22,7 +22,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin IndexBy
  */
-class IndexBySpec extends ObjectBehavior
+final class IndexBySpec extends ObjectBehavior
 {
     private $field = 'the_field';
 

--- a/tests/Query/InnerJoinSpec.php
+++ b/tests/Query/InnerJoinSpec.php
@@ -22,7 +22,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin InnerJoin
  */
-class InnerJoinSpec extends ObjectBehavior
+final class InnerJoinSpec extends ObjectBehavior
 {
     public function let(): void
     {

--- a/tests/Query/JoinSpec.php
+++ b/tests/Query/JoinSpec.php
@@ -22,7 +22,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin Join
  */
-class JoinSpec extends ObjectBehavior
+final class JoinSpec extends ObjectBehavior
 {
     public function let(): void
     {

--- a/tests/Query/LeftJoinSpec.php
+++ b/tests/Query/LeftJoinSpec.php
@@ -22,7 +22,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin LeftJoin
  */
-class LeftJoinSpec extends ObjectBehavior
+final class LeftJoinSpec extends ObjectBehavior
 {
     public function let(): void
     {

--- a/tests/Query/SelectSpec.php
+++ b/tests/Query/SelectSpec.php
@@ -23,7 +23,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin Select
  */
-class SelectSpec extends ObjectBehavior
+final class SelectSpec extends ObjectBehavior
 {
     public function let(): void
     {

--- a/tests/Query/Selection/ArgumentToSelectionConverterSpec.php
+++ b/tests/Query/Selection/ArgumentToSelectionConverterSpec.php
@@ -21,15 +21,17 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin ArgumentToSelectionConverter
  */
-class ArgumentToSelectionConverterSpec extends ObjectBehavior
+final class ArgumentToSelectionConverterSpec extends ObjectBehavior
 {
     public function it_is_a_converter(): void
     {
         $this->shouldBeAnInstanceOf(ArgumentToSelectionConverter::class);
     }
 
-    public function it_not_convert_field_to_selection(Field $field): void
+    public function it_not_convert_field_to_selection(): void
     {
+        $field = new Field('foo');
+
         $this->toSelection($field)->shouldReturn($field);
     }
 

--- a/tests/Query/Selection/SelectAsSpec.php
+++ b/tests/Query/Selection/SelectAsSpec.php
@@ -26,7 +26,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin SelectAs
  */
-class SelectAsSpec extends ObjectBehavior
+final class SelectAsSpec extends ObjectBehavior
 {
     private $field = 'foo';
 

--- a/tests/Query/Selection/SelectEntitySpec.php
+++ b/tests/Query/Selection/SelectEntitySpec.php
@@ -22,7 +22,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin SelectEntity
  */
-class SelectEntitySpec extends ObjectBehavior
+final class SelectEntitySpec extends ObjectBehavior
 {
     private $dqlAlias = 'u';
 

--- a/tests/Query/Selection/SelectHiddenAsSpec.php
+++ b/tests/Query/Selection/SelectHiddenAsSpec.php
@@ -26,7 +26,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin SelectHiddenAs
  */
-class SelectHiddenAsSpec extends ObjectBehavior
+final class SelectHiddenAsSpec extends ObjectBehavior
 {
     private $field = 'foo';
 

--- a/tests/Result/AsArraySpec.php
+++ b/tests/Result/AsArraySpec.php
@@ -23,7 +23,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin AsArray
  */
-class AsArraySpec extends ObjectBehavior
+final class AsArraySpec extends ObjectBehavior
 {
     public function it_is_a_result_modifier(): void
     {

--- a/tests/Result/AsScalarSpec.php
+++ b/tests/Result/AsScalarSpec.php
@@ -23,7 +23,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin AsScalar
  */
-class AsScalarSpec extends ObjectBehavior
+final class AsScalarSpec extends ObjectBehavior
 {
     public function it_is_a_result_modifier(): void
     {

--- a/tests/Result/AsSingleScalarSpec.php
+++ b/tests/Result/AsSingleScalarSpec.php
@@ -23,7 +23,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin AsSingleScalar
  */
-class AsSingleScalarSpec extends ObjectBehavior
+final class AsSingleScalarSpec extends ObjectBehavior
 {
     public function it_is_a_result_modifier(): void
     {

--- a/tests/Result/CacheSpec.php
+++ b/tests/Result/CacheSpec.php
@@ -22,7 +22,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin Cache
  */
-class CacheSpec extends ObjectBehavior
+final class CacheSpec extends ObjectBehavior
 {
     private $lifetime = 3600;
 

--- a/tests/Result/RoundDateTimeSpec.php
+++ b/tests/Result/RoundDateTimeSpec.php
@@ -23,7 +23,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin RoundDateTime
  */
-class RoundDateTimeSpec extends ObjectBehavior
+final class RoundDateTimeSpec extends ObjectBehavior
 {
     private $roundSeconds = 3600;
 

--- a/tests/SpecSpec.php
+++ b/tests/SpecSpec.php
@@ -36,7 +36,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin Spec
  */
-class SpecSpec extends ObjectBehavior
+final class SpecSpec extends ObjectBehavior
 {
     public function it_creates_an_x_specification(): void
     {

--- a/tests/Specification/CountOfSpec.php
+++ b/tests/Specification/CountOfSpec.php
@@ -25,7 +25,7 @@ use PhpSpec\ObjectBehavior;
 /**
  * @mixin CountOf
  */
-class CountOfSpec extends ObjectBehavior
+final class CountOfSpec extends ObjectBehavior
 {
     public function let(): void
     {


### PR DESCRIPTION
Mark specification classes as final.
You don't have to expand on existing specifications. To create your own specifications, use `BaseSpecification`.