### PR TITLE
Modulo arithmetic operand was deprecated and will be removed in 2.0

### DIFF
--- a/src/Operand/Modulo.php
+++ b/src/Operand/Modulo.php
@@ -13,6 +13,11 @@
 
 namespace Happyr\DoctrineSpecification\Operand;
 
+@trigger_error('The '.__NAMESPACE__.'\Modulo class is deprecated since version 1.1 and will be removed in 2.0, use \Happyr\DoctrineSpecification\Operand\PlatformFunction with "MOD" function name instead.', E_USER_DEPRECATED);
+
+/**
+ * @deprecated This class is deprecated since version 1.1 and will be removed in 2.0, use \Happyr\DoctrineSpecification\Operand\PlatformFunction with "MOD" function name instead.
+ */
 class Modulo extends Arithmetic
 {
     /**

--- a/src/Spec.php
+++ b/src/Spec.php
@@ -683,6 +683,8 @@ class Spec
     }
 
     /**
+     * @deprecated This method is deprecated since version 1.1 and will be removed in 2.0, use Spec::MOD() instead.
+     *
      * @param Operand|string $field
      * @param Operand|mixed  $value
      *


### PR DESCRIPTION
The Вoctrine [does not allow](https://stackoverflow.com/questions/48932492/doctrine-mod-even-date-doctrine-with-symfony) use `%` in expressions. Instead, you need to use function `MOD()` in DQL. This means that instead of operand `Modulo`, you must use operand `PlatformFunction` with argument `MOD`.