### PR TITLE
Correct resolve DQL alias in context in SelectEntity

### DIFF
--- a/src/Query/Selection/SelectEntity.php
+++ b/src/Query/Selection/SelectEntity.php
@@ -40,6 +40,6 @@ final class SelectEntity implements Selection
      */
     public function transform(QueryBuilder $qb, string $context): string
     {
-        return DQLContextResolver::resolveAlias($qb, $this->dqlAliasInContext);
+        return DQLContextResolver::resolveAlias($qb, sprintf('%s.%s', $context, $this->dqlAliasInContext));
     }
 }

--- a/tests/Query/Selection/SelectEntitySpec.php
+++ b/tests/Query/Selection/SelectEntitySpec.php
@@ -24,11 +24,11 @@ use PhpSpec\ObjectBehavior;
  */
 final class SelectEntitySpec extends ObjectBehavior
 {
-    private $context = 'u';
+    private $dqlAlias = 'u';
 
     public function let(): void
     {
-        $this->beConstructedWith($this->context);
+        $this->beConstructedWith($this->dqlAlias);
     }
 
     public function it_is_a_select_entity(): void
@@ -43,6 +43,25 @@ final class SelectEntitySpec extends ObjectBehavior
 
     public function it_is_transformable(QueryBuilder $qb): void
     {
-        $this->transform($qb, 'a')->shouldReturn($this->context);
+        $qb->getDQLPart('join')->willReturn([]);
+        $qb->getAllAliases()->willReturn([]);
+        $qb->join(sprintf('a.%s', $this->dqlAlias), $this->dqlAlias)->willReturn($qb);
+
+        $this->transform($qb, 'a')->shouldReturn($this->dqlAlias);
+    }
+
+    public function it_is_transformable_in_context(QueryBuilder $qb): void
+    {
+        $context = 'foo.bar';
+
+        $this->beConstructedWith(sprintf('%s.%s', $context, $this->dqlAlias));
+
+        $qb->getDQLPart('join')->willReturn([]);
+        $qb->getAllAliases()->willReturn([]);
+        $qb->join('a.foo', 'foo')->willReturn($qb);
+        $qb->join('foo.bar', 'bar')->willReturn($qb);
+        $qb->join(sprintf('bar.%s', $this->dqlAlias), $this->dqlAlias)->willReturn($qb);
+
+        $this->transform($qb, 'a')->shouldReturn($this->dqlAlias);
     }
 }


### PR DESCRIPTION
The path to the additional alias is specified without taking into account the root alias, and as a result, Doctrine does not know how to build joins.

Example

```php
echo $rep->getQueryBuilder(Spec::addSelect(
    Spec::selectEntity('contestant.user'),
    Spec::selectEntity('contestant'),
))->getDQL();
```

Result

```sql
SELECT
    root,
    contestant.user,
    contestant
FROM
    Questionnaire root
```

Should be

```sql
SELECT
    root,
    user,
    contestant
FROM
    Questionnaire root
INNER JOIN
    root.contestant contestant
INNER JOIN
    contestant.user user
```
