### PR TITLE
The context in Operands is optional and may not be specified

### DIFF
--- a/src/Operand/Alias.php
+++ b/src/Operand/Alias.php
@@ -48,7 +48,7 @@ final class Alias implements Operand
      * @param mixed[]|object $candidate
      * @param string|null    $context
      */
-    public function execute($candidate, ?string $context): void
+    public function execute($candidate, ?string $context = null): void
     {
         throw new OperandNotExecuteException('The aliasing is not supported for execution.');
     }

--- a/src/Operand/Arithmetic.php
+++ b/src/Operand/Arithmetic.php
@@ -95,7 +95,7 @@ abstract class Arithmetic implements Operand
      *
      * @return mixed
      */
-    public function execute($candidate, ?string $context)
+    public function execute($candidate, ?string $context = null)
     {
         $field = ArgumentToOperandConverter::toField($this->field);
         $value = ArgumentToOperandConverter::toValue($this->value);

--- a/src/Operand/Field.php
+++ b/src/Operand/Field.php
@@ -64,7 +64,7 @@ final class Field implements Operand, Selection
      *
      * @return mixed
      */
-    public function execute($candidate, ?string $context)
+    public function execute($candidate, ?string $context = null)
     {
         $propertyPath = $this->fieldName;
 

--- a/src/Operand/LikePattern.php
+++ b/src/Operand/LikePattern.php
@@ -67,7 +67,7 @@ final class LikePattern implements Operand
      *
      * @return string
      */
-    public function execute($candidate, ?string $context): string
+    public function execute($candidate, ?string $context = null): string
     {
         return $this->formatValue($this->format, $this->value);
     }

--- a/src/Operand/Operand.php
+++ b/src/Operand/Operand.php
@@ -32,5 +32,5 @@ interface Operand
      *
      * @return mixed
      */
-    public function execute($candidate, ?string $context);
+    public function execute($candidate, ?string $context = null);
 }

--- a/src/Operand/PlatformFunction.php
+++ b/src/Operand/PlatformFunction.php
@@ -123,7 +123,7 @@ final class PlatformFunction implements Operand
      *
      * @return mixed
      */
-    public function execute($candidate, ?string $context)
+    public function execute($candidate, ?string $context = null)
     {
         $arguments = [];
         foreach (ArgumentToOperandConverter::convert($this->arguments) as $argument) {

--- a/src/Operand/PlatformFunction/Avg.php
+++ b/src/Operand/PlatformFunction/Avg.php
@@ -65,7 +65,7 @@ final class Avg implements Operand
      * @param mixed[]|object $candidate
      * @param string|null    $context
      */
-    public function execute($candidate, ?string $context): void
+    public function execute($candidate, ?string $context = null): void
     {
         throw new OperandNotExecuteException(
             sprintf('The operand "%s" cannot be executed for a single candidate.', self::class)

--- a/src/Operand/PlatformFunction/Count.php
+++ b/src/Operand/PlatformFunction/Count.php
@@ -65,7 +65,7 @@ final class Count implements Operand
      * @param mixed[]|object $candidate
      * @param string|null    $context
      */
-    public function execute($candidate, ?string $context): void
+    public function execute($candidate, ?string $context = null): void
     {
         throw new OperandNotExecuteException(
             sprintf('The operand "%s" cannot be executed for a single candidate.', self::class)

--- a/src/Operand/PlatformFunction/DateAdd.php
+++ b/src/Operand/PlatformFunction/DateAdd.php
@@ -97,7 +97,7 @@ final class DateAdd implements Operand
      *
      * @return \DateTimeImmutable
      */
-    public function execute($candidate, ?string $context): \DateTimeImmutable
+    public function execute($candidate, ?string $context = null): \DateTimeImmutable
     {
         $date = ArgumentToOperandConverter::toField($this->date)->execute($candidate, $context);
         $value = ArgumentToOperandConverter::toValue($this->value)->execute($candidate, $context);

--- a/src/Operand/PlatformFunction/DateSub.php
+++ b/src/Operand/PlatformFunction/DateSub.php
@@ -97,7 +97,7 @@ final class DateSub implements Operand
      *
      * @return \DateTimeImmutable
      */
-    public function execute($candidate, ?string $context): \DateTimeImmutable
+    public function execute($candidate, ?string $context = null): \DateTimeImmutable
     {
         $date = ArgumentToOperandConverter::toField($this->date)->execute($candidate, $context);
         $value = ArgumentToOperandConverter::toValue($this->value)->execute($candidate, $context);

--- a/src/Operand/PlatformFunction/Max.php
+++ b/src/Operand/PlatformFunction/Max.php
@@ -65,7 +65,7 @@ final class Max implements Operand
      * @param mixed[]|object $candidate
      * @param string|null    $context
      */
-    public function execute($candidate, ?string $context): void
+    public function execute($candidate, ?string $context = null): void
     {
         throw new OperandNotExecuteException(
             sprintf('The operand "%s" cannot be executed for a single candidate.', self::class)

--- a/src/Operand/PlatformFunction/Min.php
+++ b/src/Operand/PlatformFunction/Min.php
@@ -65,7 +65,7 @@ final class Min implements Operand
      * @param mixed[]|object $candidate
      * @param string|null    $context
      */
-    public function execute($candidate, ?string $context): void
+    public function execute($candidate, ?string $context = null): void
     {
         throw new OperandNotExecuteException(
             sprintf('The operand "%s" cannot be executed for a single candidate.', self::class)

--- a/src/Operand/PlatformFunction/Sum.php
+++ b/src/Operand/PlatformFunction/Sum.php
@@ -65,7 +65,7 @@ final class Sum implements Operand
      * @param mixed[]|object $candidate
      * @param string|null    $context
      */
-    public function execute($candidate, ?string $context): void
+    public function execute($candidate, ?string $context = null): void
     {
         throw new OperandNotExecuteException(
             sprintf('The operand "%s" cannot be executed for a single candidate.', self::class)

--- a/src/Operand/PlatformFunction/Trim.php
+++ b/src/Operand/PlatformFunction/Trim.php
@@ -115,7 +115,7 @@ final class Trim implements Operand
      *
      * @return string
      */
-    public function execute($candidate, ?string $context): string
+    public function execute($candidate, ?string $context = null): string
     {
         $string = ArgumentToOperandConverter::toField($this->string)->execute($candidate, $context);
 

--- a/src/Operand/Value.php
+++ b/src/Operand/Value.php
@@ -60,7 +60,7 @@ final class Value implements Operand
      *
      * @return mixed
      */
-    public function execute($candidate, ?string $context)
+    public function execute($candidate, ?string $context = null)
     {
         return $this->value;
     }

--- a/src/Operand/Values.php
+++ b/src/Operand/Values.php
@@ -64,7 +64,7 @@ final class Values implements Operand
      *
      * @return mixed[]
      */
-    public function execute($candidate, ?string $context): array
+    public function execute($candidate, ?string $context = null): array
     {
         return $this->values;
     }

--- a/tests/Operand/AdditionSpec.php
+++ b/tests/Operand/AdditionSpec.php
@@ -69,7 +69,7 @@ final class AdditionSpec extends ObjectBehavior
 
         $player = new Player('Moe', 'M', 1230);
 
-        $this->execute($player, null)->shouldReturn(1330);
+        $this->execute($player)->shouldReturn(1330);
     }
 
     public function it_is_executable_object_with_operands(): void
@@ -78,7 +78,7 @@ final class AdditionSpec extends ObjectBehavior
 
         $player = new Player('Moe', 'M', 1230);
 
-        $this->execute($player, null)->shouldReturn(1330);
+        $this->execute($player)->shouldReturn(1330);
     }
 
     public function it_is_executable_array(): void
@@ -87,7 +87,7 @@ final class AdditionSpec extends ObjectBehavior
 
         $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230];
 
-        $this->execute($player, null)->shouldReturn(1330);
+        $this->execute($player)->shouldReturn(1330);
     }
 
     public function it_is_executable_array_with_operands(): void
@@ -96,6 +96,6 @@ final class AdditionSpec extends ObjectBehavior
 
         $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230];
 
-        $this->execute($player, null)->shouldReturn(1330);
+        $this->execute($player)->shouldReturn(1330);
     }
 }

--- a/tests/Operand/AliasSpec.php
+++ b/tests/Operand/AliasSpec.php
@@ -51,6 +51,6 @@ final class AliasSpec extends ObjectBehavior
     {
         $candidate = null; // not used
 
-        $this->shouldThrow(OperandNotExecuteException::class)->duringExecute($candidate, null);
+        $this->shouldThrow(OperandNotExecuteException::class)->duringExecute($candidate);
     }
 }

--- a/tests/Operand/DivisionSpec.php
+++ b/tests/Operand/DivisionSpec.php
@@ -69,7 +69,7 @@ final class DivisionSpec extends ObjectBehavior
 
         $player = new Player('Moe', 'M', 1230);
 
-        $this->execute($player, null)->shouldReturn(123);
+        $this->execute($player)->shouldReturn(123);
     }
 
     public function it_is_executable_object_with_operands(): void
@@ -78,7 +78,7 @@ final class DivisionSpec extends ObjectBehavior
 
         $player = new Player('Moe', 'M', 1230);
 
-        $this->execute($player, null)->shouldReturn(123);
+        $this->execute($player)->shouldReturn(123);
     }
 
     public function it_is_executable_array(): void
@@ -87,7 +87,7 @@ final class DivisionSpec extends ObjectBehavior
 
         $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230];
 
-        $this->execute($player, null)->shouldReturn(123);
+        $this->execute($player)->shouldReturn(123);
     }
 
     public function it_is_executable_array_with_operands(): void
@@ -96,6 +96,6 @@ final class DivisionSpec extends ObjectBehavior
 
         $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230];
 
-        $this->execute($player, null)->shouldReturn(123);
+        $this->execute($player)->shouldReturn(123);
     }
 }

--- a/tests/Operand/FieldSpec.php
+++ b/tests/Operand/FieldSpec.php
@@ -69,7 +69,7 @@ final class FieldSpec extends ObjectBehavior
 
         $player = new Player('Moe', 'M', 1230);
 
-        $this->execute($player, null)->shouldReturn($player->pseudo);
+        $this->execute($player)->shouldReturn($player->pseudo);
     }
 
     public function it_is_executable_array(): void
@@ -78,7 +78,7 @@ final class FieldSpec extends ObjectBehavior
 
         $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230];
 
-        $this->execute($player, null)->shouldReturn($player['pseudo']);
+        $this->execute($player)->shouldReturn($player['pseudo']);
     }
 
     public function it_is_executable_object_in_context(): void
@@ -88,7 +88,7 @@ final class FieldSpec extends ObjectBehavior
         $game = new Game('Tetris');
         $player = new Player('Moe', 'M', 1230, $game);
 
-        $this->execute($player, null)->shouldReturn($game->name);
+        $this->execute($player)->shouldReturn($game->name);
     }
 
     public function it_is_executable_array_in_context(): void
@@ -98,7 +98,7 @@ final class FieldSpec extends ObjectBehavior
         $game = ['name' => 'Tetris'];
         $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230, 'inGame' => $game];
 
-        $this->execute($player, null)->shouldReturn($game['name']);
+        $this->execute($player)->shouldReturn($game['name']);
     }
 
     public function it_is_executable_object_in_global_context(): void
@@ -128,7 +128,7 @@ final class FieldSpec extends ObjectBehavior
         $game = new Game('Tetris');
         $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230, 'inGame' => $game];
 
-        $this->shouldThrow(NoSuchIndexException::class)->duringExecute($player, null);
+        $this->shouldThrow(NoSuchIndexException::class)->duringExecute($player);
     }
 
     public function it_is_executable_collection(): void
@@ -142,6 +142,6 @@ final class FieldSpec extends ObjectBehavior
             ],
         ];
 
-        $this->execute($game, null)->shouldReturn(null);
+        $this->execute($game)->shouldReturn(null);
     }
 }

--- a/tests/Operand/LikePatternSpec.php
+++ b/tests/Operand/LikePatternSpec.php
@@ -60,6 +60,6 @@ final class LikePatternSpec extends ObjectBehavior
     {
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturn(sprintf($this->format, $this->value));
+        $this->execute($candidate)->shouldReturn(sprintf($this->format, $this->value));
     }
 }

--- a/tests/Operand/MultiplicationSpec.php
+++ b/tests/Operand/MultiplicationSpec.php
@@ -69,7 +69,7 @@ final class MultiplicationSpec extends ObjectBehavior
 
         $player = new Player('Moe', 'M', 1230);
 
-        $this->execute($player, null)->shouldReturn(123000);
+        $this->execute($player)->shouldReturn(123000);
     }
 
     public function it_is_executable_object_with_operands(): void
@@ -78,7 +78,7 @@ final class MultiplicationSpec extends ObjectBehavior
 
         $player = new Player('Moe', 'M', 1230);
 
-        $this->execute($player, null)->shouldReturn(123000);
+        $this->execute($player)->shouldReturn(123000);
     }
 
     public function it_is_executable_array(): void
@@ -87,7 +87,7 @@ final class MultiplicationSpec extends ObjectBehavior
 
         $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230];
 
-        $this->execute($player, null)->shouldReturn(123000);
+        $this->execute($player)->shouldReturn(123000);
     }
 
     public function it_is_executable_array_with_operands(): void
@@ -96,6 +96,6 @@ final class MultiplicationSpec extends ObjectBehavior
 
         $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230];
 
-        $this->execute($player, null)->shouldReturn(123000);
+        $this->execute($player)->shouldReturn(123000);
     }
 }

--- a/tests/Operand/PlatformFunction/AvgSpec.php
+++ b/tests/Operand/PlatformFunction/AvgSpec.php
@@ -58,6 +58,6 @@ final class AvgSpec extends ObjectBehavior
     {
         $candidate = null; // not used
 
-        $this->shouldThrow(OperandNotExecuteException::class)->duringExecute($candidate, null);
+        $this->shouldThrow(OperandNotExecuteException::class)->duringExecute($candidate);
     }
 }

--- a/tests/Operand/PlatformFunction/CountSpec.php
+++ b/tests/Operand/PlatformFunction/CountSpec.php
@@ -58,6 +58,6 @@ final class CountSpec extends ObjectBehavior
     {
         $candidate = null; // not used
 
-        $this->shouldThrow(OperandNotExecuteException::class)->duringExecute($candidate, null);
+        $this->shouldThrow(OperandNotExecuteException::class)->duringExecute($candidate);
     }
 }

--- a/tests/Operand/PlatformFunction/DateAddSpec.php
+++ b/tests/Operand/PlatformFunction/DateAddSpec.php
@@ -30,9 +30,9 @@ final class DateAddSpec extends ObjectBehavior
 
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturnInstanceOf(\DateTimeImmutable::class);
-        $this->execute($candidate, null)->shouldReturnSameTimeZone($now->getTimezone());
-        $this->execute($candidate, null)->shouldReturnSameTimestamp($now->modify('+1 year'));
+        $this->execute($candidate)->shouldReturnInstanceOf(\DateTimeImmutable::class);
+        $this->execute($candidate)->shouldReturnSameTimeZone($now->getTimezone());
+        $this->execute($candidate)->shouldReturnSameTimestamp($now->modify('+1 year'));
     }
 
     public function it_should_sub_one_year(): void
@@ -43,9 +43,9 @@ final class DateAddSpec extends ObjectBehavior
 
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
-        $this->execute($candidate, null)->shouldReturnSameTimeZone($now->getTimezone());
-        $this->execute($candidate, null)->shouldReturnSameTimestamp($now->modify('-1 year'));
+        $this->execute($candidate)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
+        $this->execute($candidate)->shouldReturnSameTimeZone($now->getTimezone());
+        $this->execute($candidate)->shouldReturnSameTimestamp($now->modify('-1 year'));
     }
 
     public function it_should_add_one_month(): void
@@ -56,9 +56,9 @@ final class DateAddSpec extends ObjectBehavior
 
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
-        $this->execute($candidate, null)->shouldReturnSameTimeZone($now->getTimezone());
-        $this->execute($candidate, null)->shouldReturnSameTimestamp($now->modify('+1 month'));
+        $this->execute($candidate)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
+        $this->execute($candidate)->shouldReturnSameTimeZone($now->getTimezone());
+        $this->execute($candidate)->shouldReturnSameTimestamp($now->modify('+1 month'));
     }
 
     public function it_should_sub_one_month(): void
@@ -69,9 +69,9 @@ final class DateAddSpec extends ObjectBehavior
 
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
-        $this->execute($candidate, null)->shouldReturnSameTimeZone($now->getTimezone());
-        $this->execute($candidate, null)->shouldReturnSameTimestamp($now->modify('-1 month'));
+        $this->execute($candidate)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
+        $this->execute($candidate)->shouldReturnSameTimeZone($now->getTimezone());
+        $this->execute($candidate)->shouldReturnSameTimestamp($now->modify('-1 month'));
     }
 
     public function it_should_add_one_week(): void
@@ -82,9 +82,9 @@ final class DateAddSpec extends ObjectBehavior
 
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
-        $this->execute($candidate, null)->shouldReturnSameTimeZone($now->getTimezone());
-        $this->execute($candidate, null)->shouldReturnSameTimestamp($now->modify('+1 week'));
+        $this->execute($candidate)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
+        $this->execute($candidate)->shouldReturnSameTimeZone($now->getTimezone());
+        $this->execute($candidate)->shouldReturnSameTimestamp($now->modify('+1 week'));
     }
 
     public function it_should_sub_one_week(): void
@@ -95,9 +95,9 @@ final class DateAddSpec extends ObjectBehavior
 
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
-        $this->execute($candidate, null)->shouldReturnSameTimeZone($now->getTimezone());
-        $this->execute($candidate, null)->shouldReturnSameTimestamp($now->modify('-1 week'));
+        $this->execute($candidate)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
+        $this->execute($candidate)->shouldReturnSameTimeZone($now->getTimezone());
+        $this->execute($candidate)->shouldReturnSameTimestamp($now->modify('-1 week'));
     }
 
     public function it_should_add_one_day(): void
@@ -108,9 +108,9 @@ final class DateAddSpec extends ObjectBehavior
 
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
-        $this->execute($candidate, null)->shouldReturnSameTimeZone($now->getTimezone());
-        $this->execute($candidate, null)->shouldReturnSameTimestamp($now->modify('+1 day'));
+        $this->execute($candidate)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
+        $this->execute($candidate)->shouldReturnSameTimeZone($now->getTimezone());
+        $this->execute($candidate)->shouldReturnSameTimestamp($now->modify('+1 day'));
     }
 
     public function it_should_sub_one_day(): void
@@ -121,9 +121,9 @@ final class DateAddSpec extends ObjectBehavior
 
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
-        $this->execute($candidate, null)->shouldReturnSameTimeZone($now->getTimezone());
-        $this->execute($candidate, null)->shouldReturnSameTimestamp($now->modify('-1 day'));
+        $this->execute($candidate)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
+        $this->execute($candidate)->shouldReturnSameTimeZone($now->getTimezone());
+        $this->execute($candidate)->shouldReturnSameTimestamp($now->modify('-1 day'));
     }
 
     public function it_should_add_one_hour(): void
@@ -134,9 +134,9 @@ final class DateAddSpec extends ObjectBehavior
 
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
-        $this->execute($candidate, null)->shouldReturnSameTimeZone($now->getTimezone());
-        $this->execute($candidate, null)->shouldReturnSameTimestamp($now->modify('+1 hour'));
+        $this->execute($candidate)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
+        $this->execute($candidate)->shouldReturnSameTimeZone($now->getTimezone());
+        $this->execute($candidate)->shouldReturnSameTimestamp($now->modify('+1 hour'));
     }
 
     public function it_should_sub_one_hour(): void
@@ -147,9 +147,9 @@ final class DateAddSpec extends ObjectBehavior
 
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
-        $this->execute($candidate, null)->shouldReturnSameTimeZone($now->getTimezone());
-        $this->execute($candidate, null)->shouldReturnSameTimestamp($now->modify('-1 hour'));
+        $this->execute($candidate)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
+        $this->execute($candidate)->shouldReturnSameTimeZone($now->getTimezone());
+        $this->execute($candidate)->shouldReturnSameTimestamp($now->modify('-1 hour'));
     }
 
     public function it_should_add_one_minute(): void
@@ -160,9 +160,9 @@ final class DateAddSpec extends ObjectBehavior
 
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
-        $this->execute($candidate, null)->shouldReturnSameTimeZone($now->getTimezone());
-        $this->execute($candidate, null)->shouldReturnSameTimestamp($now->modify('+1 minute'));
+        $this->execute($candidate)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
+        $this->execute($candidate)->shouldReturnSameTimeZone($now->getTimezone());
+        $this->execute($candidate)->shouldReturnSameTimestamp($now->modify('+1 minute'));
     }
 
     public function it_should_sub_one_minute(): void
@@ -173,9 +173,9 @@ final class DateAddSpec extends ObjectBehavior
 
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
-        $this->execute($candidate, null)->shouldReturnSameTimeZone($now->getTimezone());
-        $this->execute($candidate, null)->shouldReturnSameTimestamp($now->modify('-1 minute'));
+        $this->execute($candidate)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
+        $this->execute($candidate)->shouldReturnSameTimeZone($now->getTimezone());
+        $this->execute($candidate)->shouldReturnSameTimestamp($now->modify('-1 minute'));
     }
 
     public function it_should_add_one_second(): void
@@ -186,9 +186,9 @@ final class DateAddSpec extends ObjectBehavior
 
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
-        $this->execute($candidate, null)->shouldReturnSameTimeZone($now->getTimezone());
-        $this->execute($candidate, null)->shouldReturnSameTimestamp($now->modify('+1 second'));
+        $this->execute($candidate)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
+        $this->execute($candidate)->shouldReturnSameTimeZone($now->getTimezone());
+        $this->execute($candidate)->shouldReturnSameTimestamp($now->modify('+1 second'));
     }
 
     public function it_should_sub_one_second(): void
@@ -199,9 +199,9 @@ final class DateAddSpec extends ObjectBehavior
 
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
-        $this->execute($candidate, null)->shouldReturnSameTimeZone($now->getTimezone());
-        $this->execute($candidate, null)->shouldReturnSameTimestamp($now->modify('-1 second'));
+        $this->execute($candidate)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
+        $this->execute($candidate)->shouldReturnSameTimeZone($now->getTimezone());
+        $this->execute($candidate)->shouldReturnSameTimestamp($now->modify('-1 second'));
     }
 
     public function getMatchers(): array

--- a/tests/Operand/PlatformFunction/DateSubSpec.php
+++ b/tests/Operand/PlatformFunction/DateSubSpec.php
@@ -30,9 +30,9 @@ final class DateSubSpec extends ObjectBehavior
 
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
-        $this->execute($candidate, null)->shouldReturnSameTimeZone($now->getTimezone());
-        $this->execute($candidate, null)->shouldReturnSameTimestamp($now->modify('+1 year'));
+        $this->execute($candidate)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
+        $this->execute($candidate)->shouldReturnSameTimeZone($now->getTimezone());
+        $this->execute($candidate)->shouldReturnSameTimestamp($now->modify('+1 year'));
     }
 
     public function it_should_sub_one_year(): void
@@ -43,9 +43,9 @@ final class DateSubSpec extends ObjectBehavior
 
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
-        $this->execute($candidate, null)->shouldReturnSameTimeZone($now->getTimezone());
-        $this->execute($candidate, null)->shouldReturnSameTimestamp($now->modify('-1 year'));
+        $this->execute($candidate)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
+        $this->execute($candidate)->shouldReturnSameTimeZone($now->getTimezone());
+        $this->execute($candidate)->shouldReturnSameTimestamp($now->modify('-1 year'));
     }
 
     public function it_should_add_one_month(): void
@@ -56,9 +56,9 @@ final class DateSubSpec extends ObjectBehavior
 
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
-        $this->execute($candidate, null)->shouldReturnSameTimeZone($now->getTimezone());
-        $this->execute($candidate, null)->shouldReturnSameTimestamp($now->modify('+1 month'));
+        $this->execute($candidate)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
+        $this->execute($candidate)->shouldReturnSameTimeZone($now->getTimezone());
+        $this->execute($candidate)->shouldReturnSameTimestamp($now->modify('+1 month'));
     }
 
     public function it_should_sub_one_month(): void
@@ -69,9 +69,9 @@ final class DateSubSpec extends ObjectBehavior
 
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
-        $this->execute($candidate, null)->shouldReturnSameTimeZone($now->getTimezone());
-        $this->execute($candidate, null)->shouldReturnSameTimestamp($now->modify('-1 month'));
+        $this->execute($candidate)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
+        $this->execute($candidate)->shouldReturnSameTimeZone($now->getTimezone());
+        $this->execute($candidate)->shouldReturnSameTimestamp($now->modify('-1 month'));
     }
 
     public function it_should_add_one_week(): void
@@ -82,9 +82,9 @@ final class DateSubSpec extends ObjectBehavior
 
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
-        $this->execute($candidate, null)->shouldReturnSameTimeZone($now->getTimezone());
-        $this->execute($candidate, null)->shouldReturnSameTimestamp($now->modify('+1 week'));
+        $this->execute($candidate)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
+        $this->execute($candidate)->shouldReturnSameTimeZone($now->getTimezone());
+        $this->execute($candidate)->shouldReturnSameTimestamp($now->modify('+1 week'));
     }
 
     public function it_should_sub_one_week(): void
@@ -95,9 +95,9 @@ final class DateSubSpec extends ObjectBehavior
 
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
-        $this->execute($candidate, null)->shouldReturnSameTimeZone($now->getTimezone());
-        $this->execute($candidate, null)->shouldReturnSameTimestamp($now->modify('-1 week'));
+        $this->execute($candidate)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
+        $this->execute($candidate)->shouldReturnSameTimeZone($now->getTimezone());
+        $this->execute($candidate)->shouldReturnSameTimestamp($now->modify('-1 week'));
     }
 
     public function it_should_add_one_day(): void
@@ -108,9 +108,9 @@ final class DateSubSpec extends ObjectBehavior
 
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
-        $this->execute($candidate, null)->shouldReturnSameTimeZone($now->getTimezone());
-        $this->execute($candidate, null)->shouldReturnSameTimestamp($now->modify('+1 day'));
+        $this->execute($candidate)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
+        $this->execute($candidate)->shouldReturnSameTimeZone($now->getTimezone());
+        $this->execute($candidate)->shouldReturnSameTimestamp($now->modify('+1 day'));
     }
 
     public function it_should_sub_one_day(): void
@@ -121,9 +121,9 @@ final class DateSubSpec extends ObjectBehavior
 
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
-        $this->execute($candidate, null)->shouldReturnSameTimeZone($now->getTimezone());
-        $this->execute($candidate, null)->shouldReturnSameTimestamp($now->modify('-1 day'));
+        $this->execute($candidate)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
+        $this->execute($candidate)->shouldReturnSameTimeZone($now->getTimezone());
+        $this->execute($candidate)->shouldReturnSameTimestamp($now->modify('-1 day'));
     }
 
     public function it_should_add_one_hour(): void
@@ -134,9 +134,9 @@ final class DateSubSpec extends ObjectBehavior
 
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
-        $this->execute($candidate, null)->shouldReturnSameTimeZone($now->getTimezone());
-        $this->execute($candidate, null)->shouldReturnSameTimestamp($now->modify('+1 hour'));
+        $this->execute($candidate)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
+        $this->execute($candidate)->shouldReturnSameTimeZone($now->getTimezone());
+        $this->execute($candidate)->shouldReturnSameTimestamp($now->modify('+1 hour'));
     }
 
     public function it_should_sub_one_hour(): void
@@ -147,9 +147,9 @@ final class DateSubSpec extends ObjectBehavior
 
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
-        $this->execute($candidate, null)->shouldReturnSameTimeZone($now->getTimezone());
-        $this->execute($candidate, null)->shouldReturnSameTimestamp($now->modify('-1 hour'));
+        $this->execute($candidate)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
+        $this->execute($candidate)->shouldReturnSameTimeZone($now->getTimezone());
+        $this->execute($candidate)->shouldReturnSameTimestamp($now->modify('-1 hour'));
     }
 
     public function it_should_add_one_minute(): void
@@ -160,9 +160,9 @@ final class DateSubSpec extends ObjectBehavior
 
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
-        $this->execute($candidate, null)->shouldReturnSameTimeZone($now->getTimezone());
-        $this->execute($candidate, null)->shouldReturnSameTimestamp($now->modify('+1 minute'));
+        $this->execute($candidate)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
+        $this->execute($candidate)->shouldReturnSameTimeZone($now->getTimezone());
+        $this->execute($candidate)->shouldReturnSameTimestamp($now->modify('+1 minute'));
     }
 
     public function it_should_sub_one_minute(): void
@@ -173,9 +173,9 @@ final class DateSubSpec extends ObjectBehavior
 
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
-        $this->execute($candidate, null)->shouldReturnSameTimeZone($now->getTimezone());
-        $this->execute($candidate, null)->shouldReturnSameTimestamp($now->modify('-1 minute'));
+        $this->execute($candidate)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
+        $this->execute($candidate)->shouldReturnSameTimeZone($now->getTimezone());
+        $this->execute($candidate)->shouldReturnSameTimestamp($now->modify('-1 minute'));
     }
 
     public function it_should_add_one_second(): void
@@ -186,9 +186,9 @@ final class DateSubSpec extends ObjectBehavior
 
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
-        $this->execute($candidate, null)->shouldReturnSameTimeZone($now->getTimezone());
-        $this->execute($candidate, null)->shouldReturnSameTimestamp($now->modify('+1 second'));
+        $this->execute($candidate)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
+        $this->execute($candidate)->shouldReturnSameTimeZone($now->getTimezone());
+        $this->execute($candidate)->shouldReturnSameTimestamp($now->modify('+1 second'));
     }
 
     public function it_should_sub_one_second(): void
@@ -199,9 +199,9 @@ final class DateSubSpec extends ObjectBehavior
 
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
-        $this->execute($candidate, null)->shouldReturnSameTimeZone($now->getTimezone());
-        $this->execute($candidate, null)->shouldReturnSameTimestamp($now->modify('-1 second'));
+        $this->execute($candidate)->shouldReturnAnInstanceOf(\DateTimeImmutable::class);
+        $this->execute($candidate)->shouldReturnSameTimeZone($now->getTimezone());
+        $this->execute($candidate)->shouldReturnSameTimestamp($now->modify('-1 second'));
     }
 
     public function getMatchers(): array

--- a/tests/Operand/PlatformFunction/MaxSpec.php
+++ b/tests/Operand/PlatformFunction/MaxSpec.php
@@ -58,6 +58,6 @@ final class MaxSpec extends ObjectBehavior
     {
         $candidate = null; // not used
 
-        $this->shouldThrow(OperandNotExecuteException::class)->duringExecute($candidate, null);
+        $this->shouldThrow(OperandNotExecuteException::class)->duringExecute($candidate);
     }
 }

--- a/tests/Operand/PlatformFunction/MinSpec.php
+++ b/tests/Operand/PlatformFunction/MinSpec.php
@@ -58,6 +58,6 @@ final class MinSpec extends ObjectBehavior
     {
         $candidate = null; // not used
 
-        $this->shouldThrow(OperandNotExecuteException::class)->duringExecute($candidate, null);
+        $this->shouldThrow(OperandNotExecuteException::class)->duringExecute($candidate);
     }
 }

--- a/tests/Operand/PlatformFunction/SumSpec.php
+++ b/tests/Operand/PlatformFunction/SumSpec.php
@@ -58,6 +58,6 @@ final class SumSpec extends ObjectBehavior
     {
         $candidate = null; // not used
 
-        $this->shouldThrow(OperandNotExecuteException::class)->duringExecute($candidate, null);
+        $this->shouldThrow(OperandNotExecuteException::class)->duringExecute($candidate);
     }
 }

--- a/tests/Operand/PlatformFunction/TrimSpec.php
+++ b/tests/Operand/PlatformFunction/TrimSpec.php
@@ -102,7 +102,7 @@ final class TrimSpec extends ObjectBehavior
 
         $player = new Player(' Moe ', 'M', 1230);
 
-        $this->execute($player, null)->shouldReturn('Moe');
+        $this->execute($player)->shouldReturn('Moe');
     }
 
     public function it_should_execute_leading(): void
@@ -111,7 +111,7 @@ final class TrimSpec extends ObjectBehavior
 
         $player = new Player(' Moe ', 'M', 1230);
 
-        $this->execute($player, null)->shouldReturn('Moe ');
+        $this->execute($player)->shouldReturn('Moe ');
     }
 
     public function it_should_execute_trailing(): void
@@ -120,7 +120,7 @@ final class TrimSpec extends ObjectBehavior
 
         $player = new Player(' Moe ', 'M', 1230);
 
-        $this->execute($player, null)->shouldReturn(' Moe');
+        $this->execute($player)->shouldReturn(' Moe');
     }
 
     public function it_should_execute_both(): void
@@ -129,7 +129,7 @@ final class TrimSpec extends ObjectBehavior
 
         $player = new Player(' Moe ', 'M', 1230);
 
-        $this->execute($player, null)->shouldReturn('Moe');
+        $this->execute($player)->shouldReturn('Moe');
     }
 
     public function it_should_execute_with_characters(): void
@@ -138,7 +138,7 @@ final class TrimSpec extends ObjectBehavior
 
         $player = new Player('$Moe$', 'M', 1230);
 
-        $this->execute($player, null)->shouldReturn('Moe');
+        $this->execute($player)->shouldReturn('Moe');
     }
 
     public function it_should_execute_leading_with_characters(): void
@@ -147,7 +147,7 @@ final class TrimSpec extends ObjectBehavior
 
         $player = new Player('$Moe$', 'M', 1230);
 
-        $this->execute($player, null)->shouldReturn('Moe$');
+        $this->execute($player)->shouldReturn('Moe$');
     }
 
     public function it_should_execute_trailing_with_characters(): void
@@ -156,7 +156,7 @@ final class TrimSpec extends ObjectBehavior
 
         $player = new Player('$Moe$', 'M', 1230);
 
-        $this->execute($player, null)->shouldReturn('$Moe');
+        $this->execute($player)->shouldReturn('$Moe');
     }
 
     public function it_should_execute_both_with_characters(): void
@@ -165,6 +165,6 @@ final class TrimSpec extends ObjectBehavior
 
         $player = new Player('$Moe$', 'M', 1230);
 
-        $this->execute($player, null)->shouldReturn('Moe');
+        $this->execute($player)->shouldReturn('Moe');
     }
 }

--- a/tests/Operand/PlatformFunctionSpec.php
+++ b/tests/Operand/PlatformFunctionSpec.php
@@ -181,7 +181,7 @@ final class PlatformFunctionSpec extends ObjectBehavior
 
         $player = new Player('Moe', 'M', 1230);
 
-        $this->execute($player, null)->shouldReturn('MOE');
+        $this->execute($player)->shouldReturn('MOE');
     }
 
     public function it_is_executable_array(): void
@@ -190,7 +190,7 @@ final class PlatformFunctionSpec extends ObjectBehavior
 
         $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230];
 
-        $this->execute($player, null)->shouldReturn('MOE');
+        $this->execute($player)->shouldReturn('MOE');
     }
 
     public function it_is_executable_object_with_operands(): void
@@ -199,7 +199,7 @@ final class PlatformFunctionSpec extends ObjectBehavior
 
         $player = new Player('Moe', 'M', 1230);
 
-        $this->execute($player, null)->shouldReturn('MOE');
+        $this->execute($player)->shouldReturn('MOE');
     }
 
     public function it_is_executable_array_with_operands(): void
@@ -208,6 +208,6 @@ final class PlatformFunctionSpec extends ObjectBehavior
 
         $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230];
 
-        $this->execute($player, null)->shouldReturn('MOE');
+        $this->execute($player)->shouldReturn('MOE');
     }
 }

--- a/tests/Operand/SubtractionSpec.php
+++ b/tests/Operand/SubtractionSpec.php
@@ -69,7 +69,7 @@ final class SubtractionSpec extends ObjectBehavior
 
         $player = new Player('Moe', 'M', 1230);
 
-        $this->execute($player, null)->shouldReturn(1130);
+        $this->execute($player)->shouldReturn(1130);
     }
 
     public function it_is_executable_object_with_operands(): void
@@ -78,7 +78,7 @@ final class SubtractionSpec extends ObjectBehavior
 
         $player = new Player('Moe', 'M', 1230);
 
-        $this->execute($player, null)->shouldReturn(1130);
+        $this->execute($player)->shouldReturn(1130);
     }
 
     public function it_is_executable_array(): void
@@ -87,7 +87,7 @@ final class SubtractionSpec extends ObjectBehavior
 
         $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230];
 
-        $this->execute($player, null)->shouldReturn(1130);
+        $this->execute($player)->shouldReturn(1130);
     }
 
     public function it_is_executable_array_with_operands(): void
@@ -96,6 +96,6 @@ final class SubtractionSpec extends ObjectBehavior
 
         $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230];
 
-        $this->execute($player, null)->shouldReturn(1130);
+        $this->execute($player)->shouldReturn(1130);
     }
 }

--- a/tests/Operand/ValueSpec.php
+++ b/tests/Operand/ValueSpec.php
@@ -87,6 +87,6 @@ final class ValueSpec extends ObjectBehavior
     {
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturn($this->value);
+        $this->execute($candidate)->shouldReturn($this->value);
     }
 }

--- a/tests/Operand/ValuesSpec.php
+++ b/tests/Operand/ValuesSpec.php
@@ -87,6 +87,6 @@ final class ValuesSpec extends ObjectBehavior
     {
         $candidate = null; // not used
 
-        $this->execute($candidate, null)->shouldReturn($this->values);
+        $this->execute($candidate)->shouldReturn($this->values);
     }
 }


### PR DESCRIPTION
You can execute operands without explicitly specifying the execution context.