### PR TITLE
Allow use context in Satisfiable methods

### DIFF
--- a/docs/1-creatingSpecs.md
+++ b/docs/1-creatingSpecs.md
@@ -54,13 +54,13 @@ public function modify(AbstractQuery $query): void
 You can write a rule with which you will filter the collection of entities and discard non-matching entities.
 
 ```php
-public function filterCollection(iterable $collection): iterable
+public function filterCollection(iterable $collection, ?string $context = null): iterable
 {
     $field = ArgumentToOperandConverter::toField($this->field);
     $value = ArgumentToOperandConverter::toValue($this->value);
 
     foreach ($collection as $candidate) {
-        if ($field->execute($candidate) === $value->execute($candidate))) {
+        if ($field->execute($candidate, $context) === $value->execute($candidate, $context))) {
             yield $candidate;
         }
     }
@@ -72,12 +72,12 @@ public function filterCollection(iterable $collection): iterable
 You can check a specific entity against a specific rule.
 
 ```php
-public function isSatisfiedBy($candidate): bool
+public function isSatisfiedBy($candidate, ?string $context = null): bool
 {
     $field = ArgumentToOperandConverter::toField($this->field);
     $value = ArgumentToOperandConverter::toValue($this->value);
 
-    return $field->execute($candidate) >= $value->execute($candidate);
+    return $field->execute($candidate, $context) >= $value->execute($candidate, $context);
 }
 ```
 
@@ -117,7 +117,7 @@ class IsActive extends BaseSpecification
 You also don't need to worry about joins. The Happyr Doctrine Specification will do everything for you.
 
 ```php
-use Happyr\DoctrineSpecification\BaseSpecification;
+use Happyr\DoctrineSpecification\Specification\BaseSpecification;
 use Happyr\DoctrineSpecification\Spec;
 
 /**

--- a/src/Filter/Comparison.php
+++ b/src/Filter/Comparison.php
@@ -119,16 +119,14 @@ abstract class Comparison implements Filter, Satisfiable
     /**
      * {@inheritdoc}
      */
-    public function filterCollection(iterable $collection): iterable
+    public function filterCollection(iterable $collection, ?string $context = null): iterable
     {
+        $context = $this->resolveContext($context);
         $field = ArgumentToOperandConverter::toField($this->field);
         $value = ArgumentToOperandConverter::toValue($this->value);
 
         foreach ($collection as $candidate) {
-            if ($this->compare(
-                $field->execute($candidate, $this->context),
-                $value->execute($candidate, $this->context)
-            )) {
+            if ($this->compare($field->execute($candidate, $context), $value->execute($candidate, $context))) {
                 yield $candidate;
             }
         }
@@ -137,15 +135,31 @@ abstract class Comparison implements Filter, Satisfiable
     /**
      * {@inheritdoc}
      */
-    public function isSatisfiedBy($candidate): bool
+    public function isSatisfiedBy($candidate, ?string $context = null): bool
     {
+        $context = $this->resolveContext($context);
         $field = ArgumentToOperandConverter::toField($this->field);
         $value = ArgumentToOperandConverter::toValue($this->value);
 
-        return $this->compare(
-            $field->execute($candidate, $this->context),
-            $value->execute($candidate, $this->context)
-        );
+        return $this->compare($field->execute($candidate, $context), $value->execute($candidate, $context));
+    }
+
+    /**
+     * @param string|null $context
+     *
+     * @return string|null
+     */
+    private function resolveContext(?string $context): ?string
+    {
+        if (null !== $this->context && null !== $context) {
+            return sprintf('%s.%s', $context, $this->context);
+        }
+
+        if (null !== $this->context) {
+            return $this->context;
+        }
+
+        return $context;
     }
 
     /**

--- a/src/Filter/In.php
+++ b/src/Filter/In.php
@@ -73,16 +73,14 @@ final class In implements Filter, Satisfiable
     /**
      * {@inheritdoc}
      */
-    public function filterCollection(iterable $collection): iterable
+    public function filterCollection(iterable $collection, ?string $context = null): iterable
     {
+        $context = $this->resolveContext($context);
         $field = ArgumentToOperandConverter::toField($this->field);
         $value = ArgumentToOperandConverter::toValue($this->value);
 
         foreach ($collection as $candidate) {
-            if ($this->contains(
-                $field->execute($candidate, $this->context),
-                $value->execute($candidate, $this->context)
-            )) {
+            if ($this->contains($field->execute($candidate, $context), $value->execute($candidate, $context))) {
                 yield $candidate;
             }
         }
@@ -91,15 +89,31 @@ final class In implements Filter, Satisfiable
     /**
      * {@inheritdoc}
      */
-    public function isSatisfiedBy($candidate): bool
+    public function isSatisfiedBy($candidate, ?string $context = null): bool
     {
+        $context = $this->resolveContext($context);
         $field = ArgumentToOperandConverter::toField($this->field);
         $value = ArgumentToOperandConverter::toValue($this->value);
 
-        return $this->contains(
-            $field->execute($candidate, $this->context),
-            $value->execute($candidate, $this->context)
-        );
+        return $this->contains($field->execute($candidate, $context), $value->execute($candidate, $context));
+    }
+
+    /**
+     * @param string|null $context
+     *
+     * @return string|null
+     */
+    private function resolveContext(?string $context): ?string
+    {
+        if (null !== $this->context && null !== $context) {
+            return sprintf('%s.%s', $context, $this->context);
+        }
+
+        if (null !== $this->context) {
+            return $this->context;
+        }
+
+        return $context;
     }
 
     /**

--- a/src/Filter/InstanceOfX.php
+++ b/src/Filter/InstanceOfX.php
@@ -59,7 +59,7 @@ final class InstanceOfX implements Filter, Satisfiable
     /**
      * {@inheritdoc}
      */
-    public function filterCollection(iterable $collection): iterable
+    public function filterCollection(iterable $collection, ?string $context = null): iterable
     {
         foreach ($collection as $candidate) {
             if ($candidate instanceof $this->value) {
@@ -71,7 +71,7 @@ final class InstanceOfX implements Filter, Satisfiable
     /**
      * {@inheritdoc}
      */
-    public function isSatisfiedBy($candidate): bool
+    public function isSatisfiedBy($candidate, ?string $context = null): bool
     {
         return $candidate instanceof $this->value;
     }

--- a/src/Filter/IsNotNull.php
+++ b/src/Filter/IsNotNull.php
@@ -60,12 +60,13 @@ final class IsNotNull implements Filter, Satisfiable
     /**
      * {@inheritdoc}
      */
-    public function filterCollection(iterable $collection): iterable
+    public function filterCollection(iterable $collection, ?string $context = null): iterable
     {
+        $context = $this->resolveContext($context);
         $field = ArgumentToOperandConverter::toField($this->field);
 
         foreach ($collection as $candidate) {
-            if (null !== $field->execute($candidate, $this->context)) {
+            if (null !== $field->execute($candidate, $context)) {
                 yield $candidate;
             }
         }
@@ -74,10 +75,29 @@ final class IsNotNull implements Filter, Satisfiable
     /**
      * {@inheritdoc}
      */
-    public function isSatisfiedBy($candidate): bool
+    public function isSatisfiedBy($candidate, ?string $context = null): bool
     {
+        $context = $this->resolveContext($context);
         $field = ArgumentToOperandConverter::toField($this->field);
 
-        return null !== $field->execute($candidate, $this->context);
+        return null !== $field->execute($candidate, $context);
+    }
+
+    /**
+     * @param string|null $context
+     *
+     * @return string|null
+     */
+    private function resolveContext(?string $context): ?string
+    {
+        if (null !== $this->context && null !== $context) {
+            return sprintf('%s.%s', $context, $this->context);
+        }
+
+        if (null !== $this->context) {
+            return $this->context;
+        }
+
+        return $context;
     }
 }

--- a/src/Filter/IsNull.php
+++ b/src/Filter/IsNull.php
@@ -60,12 +60,13 @@ final class IsNull implements Filter, Satisfiable
     /**
      * {@inheritdoc}
      */
-    public function filterCollection(iterable $collection): iterable
+    public function filterCollection(iterable $collection, ?string $context = null): iterable
     {
+        $context = $this->resolveContext($context);
         $field = ArgumentToOperandConverter::toField($this->field);
 
         foreach ($collection as $candidate) {
-            if (null === $field->execute($candidate, $this->context)) {
+            if (null === $field->execute($candidate, $context)) {
                 yield $candidate;
             }
         }
@@ -74,10 +75,29 @@ final class IsNull implements Filter, Satisfiable
     /**
      * {@inheritdoc}
      */
-    public function isSatisfiedBy($candidate): bool
+    public function isSatisfiedBy($candidate, ?string $context = null): bool
     {
+        $context = $this->resolveContext($context);
         $field = ArgumentToOperandConverter::toField($this->field);
 
-        return null === $field->execute($candidate, $this->context);
+        return null === $field->execute($candidate, $context);
+    }
+
+    /**
+     * @param string|null $context
+     *
+     * @return string|null
+     */
+    private function resolveContext(?string $context): ?string
+    {
+        if (null !== $this->context && null !== $context) {
+            return sprintf('%s.%s', $context, $this->context);
+        }
+
+        if (null !== $this->context) {
+            return $this->context;
+        }
+
+        return $context;
     }
 }

--- a/src/Filter/Like.php
+++ b/src/Filter/Like.php
@@ -83,13 +83,14 @@ final class Like implements Filter, Satisfiable
     /**
      * {@inheritdoc}
      */
-    public function filterCollection(iterable $collection): iterable
+    public function filterCollection(iterable $collection, ?string $context = null): iterable
     {
+        $context = $this->resolveContext($context);
         $field = ArgumentToOperandConverter::toField($this->field);
         $value = $this->getUnescapedValue();
 
         foreach ($collection as $candidate) {
-            if ($this->isMatch($field->execute($candidate, $this->context), $value)) {
+            if ($this->isMatch($field->execute($candidate, $context), $value)) {
                 yield $candidate;
             }
         }
@@ -98,12 +99,31 @@ final class Like implements Filter, Satisfiable
     /**
      * {@inheritdoc}
      */
-    public function isSatisfiedBy($candidate): bool
+    public function isSatisfiedBy($candidate, ?string $context = null): bool
     {
+        $context = $this->resolveContext($context);
         $field = ArgumentToOperandConverter::toField($this->field);
         $value = $this->getUnescapedValue();
 
-        return $this->isMatch($field->execute($candidate, $this->context), $value);
+        return $this->isMatch($field->execute($candidate, $context), $value);
+    }
+
+    /**
+     * @param string|null $context
+     *
+     * @return string|null
+     */
+    private function resolveContext(?string $context): ?string
+    {
+        if (null !== $this->context && null !== $context) {
+            return sprintf('%s.%s', $context, $this->context);
+        }
+
+        if (null !== $this->context) {
+            return $this->context;
+        }
+
+        return $context;
     }
 
     /**

--- a/src/Filter/Satisfiable.php
+++ b/src/Filter/Satisfiable.php
@@ -17,7 +17,8 @@ namespace Happyr\DoctrineSpecification\Filter;
 interface Satisfiable
 {
     /**
-     * @param iterable $collection
+     * @param iterable    $collection
+     * @param string|null $context
      *
      * @return iterable
      *
@@ -25,12 +26,13 @@ interface Satisfiable
      * @phpstan-param iterable<T> $collection
      * @phpstan-return iterable<T>
      */
-    public function filterCollection(iterable $collection): iterable;
+    public function filterCollection(iterable $collection, ?string $context = null): iterable;
 
     /**
      * @param mixed[]|object $candidate
+     * @param string|null    $context
      *
      * @return bool
      */
-    public function isSatisfiedBy($candidate): bool;
+    public function isSatisfiedBy($candidate, ?string $context = null): bool;
 }

--- a/src/Logic/LogicX.php
+++ b/src/Logic/LogicX.php
@@ -101,10 +101,10 @@ abstract class LogicX implements Specification
     /**
      * {@inheritdoc}
      */
-    public function filterCollection(iterable $collection): iterable
+    public function filterCollection(iterable $collection, ?string $context = null): iterable
     {
         foreach ($collection as $candidate) {
-            if ($this->isSatisfiedBy($candidate)) {
+            if ($this->isSatisfiedBy($candidate, $context)) {
                 yield $candidate;
             }
         }
@@ -113,7 +113,7 @@ abstract class LogicX implements Specification
     /**
      * {@inheritdoc}
      */
-    public function isSatisfiedBy($candidate): bool
+    public function isSatisfiedBy($candidate, ?string $context = null): bool
     {
         $has_satisfiable_children = false;
 
@@ -124,7 +124,7 @@ abstract class LogicX implements Specification
 
             $has_satisfiable_children = true;
 
-            $satisfied = $child->isSatisfiedBy($candidate);
+            $satisfied = $child->isSatisfiedBy($candidate, $context);
 
             if ($satisfied && self::OR_X === $this->expression) {
                 return true;

--- a/src/Logic/Not.php
+++ b/src/Logic/Not.php
@@ -60,10 +60,10 @@ final class Not implements Specification
     /**
      * {@inheritdoc}
      */
-    public function filterCollection(iterable $collection): iterable
+    public function filterCollection(iterable $collection, ?string $context = null): iterable
     {
         foreach ($collection as $candidate) {
-            if (!$this->child instanceof Satisfiable || !$this->child->isSatisfiedBy($candidate)) {
+            if (!$this->child instanceof Satisfiable || !$this->child->isSatisfiedBy($candidate, $context)) {
                 yield $candidate;
             }
         }
@@ -72,8 +72,8 @@ final class Not implements Specification
     /**
      * {@inheritdoc}
      */
-    public function isSatisfiedBy($candidate): bool
+    public function isSatisfiedBy($candidate, ?string $context = null): bool
     {
-        return !$this->child instanceof Satisfiable || !$this->child->isSatisfiedBy($candidate);
+        return !$this->child instanceof Satisfiable || !$this->child->isSatisfiedBy($candidate, $context);
     }
 }

--- a/src/Specification/BaseSpecification.php
+++ b/src/Specification/BaseSpecification.php
@@ -70,12 +70,12 @@ abstract class BaseSpecification implements Specification
     /**
      * {@inheritdoc}
      */
-    public function filterCollection(iterable $collection): iterable
+    public function filterCollection(iterable $collection, ?string $context = null): iterable
     {
         $spec = $this->getSpec();
 
         if ($spec instanceof Satisfiable) {
-            return $spec->filterCollection($collection);
+            return $spec->filterCollection($collection, $context);
         }
 
         return $collection;
@@ -84,12 +84,12 @@ abstract class BaseSpecification implements Specification
     /**
      * {@inheritdoc}
      */
-    public function isSatisfiedBy($candidate): bool
+    public function isSatisfiedBy($candidate, ?string $context = null): bool
     {
         $spec = $this->getSpec();
 
         if ($spec instanceof Satisfiable) {
-            return $spec->isSatisfiedBy($candidate);
+            return $spec->isSatisfiedBy($candidate, $context);
         }
 
         return true;

--- a/src/Specification/CountOf.php
+++ b/src/Specification/CountOf.php
@@ -68,10 +68,10 @@ final class CountOf implements Specification
     /**
      * {@inheritdoc}
      */
-    public function filterCollection(iterable $collection): iterable
+    public function filterCollection(iterable $collection, ?string $context = null): iterable
     {
         if ($this->child instanceof Satisfiable) {
-            return $this->child->filterCollection($collection);
+            return $this->child->filterCollection($collection, $context);
         }
 
         return $collection;
@@ -80,10 +80,10 @@ final class CountOf implements Specification
     /**
      * {@inheritdoc}
      */
-    public function isSatisfiedBy($candidate): bool
+    public function isSatisfiedBy($candidate, ?string $context = null): bool
     {
         if ($this->child instanceof Satisfiable) {
-            return $this->child->isSatisfiedBy($candidate);
+            return $this->child->isSatisfiedBy($candidate, $context);
         }
 
         return true;

--- a/tests/Filter/EqualsSpec.php
+++ b/tests/Filter/EqualsSpec.php
@@ -134,4 +134,71 @@ final class EqualsSpec extends ObjectBehavior
 
         $this->isSatisfiedBy($player)->shouldBe(true);
     }
+
+    public function it_filter_array_collection_in_context(): void
+    {
+        $releaseAt = new \DateTimeImmutable();
+        $game = ['name' => 'Tetris', 'releaseAt' => $releaseAt];
+        $players = [
+            ['pseudo' => 'Joe',   'gender' => 'M', 'points' => 2500],
+            ['pseudo' => 'Moe',   'gender' => 'M', 'points' => 1230],
+            ['pseudo' => 'Alice', 'gender' => 'F', 'points' => 9001, 'inGame' => $game],
+        ];
+
+        $this->beConstructedWith('releaseAt', $releaseAt, 'inGame');
+
+        $this->filterCollection($players)->shouldYield([$players[2]]);
+    }
+
+    public function it_filter_array_collection_in_global_context(): void
+    {
+        $releaseAt = new \DateTimeImmutable();
+        $game = ['name' => 'Tetris', 'releaseAt' => $releaseAt];
+        $players = [
+            ['pseudo' => 'Joe',   'gender' => 'M', 'points' => 2500],
+            ['pseudo' => 'Moe',   'gender' => 'M', 'points' => 1230],
+            ['pseudo' => 'Alice', 'gender' => 'F', 'points' => 9001, 'inGame' => $game],
+        ];
+
+        $this->beConstructedWith('releaseAt', $releaseAt, null);
+
+        $this->filterCollection($players, 'inGame')->shouldYield([$players[2]]);
+    }
+
+    public function it_is_satisfied_in_global_context(): void
+    {
+        $releaseAt = new \DateTimeImmutable();
+        $game = ['name' => 'Tetris', 'releaseAt' => $releaseAt];
+        $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230, 'inGame' => $game];
+
+        $this->beConstructedWith('releaseAt', $releaseAt, null);
+
+        $this->isSatisfiedBy($player, 'inGame')->shouldBe(true);
+    }
+
+    public function it_filter_array_collection_in_combo_context(): void
+    {
+        $owner = ['name' => 'ABC', 'based' => 123];
+        $game = ['name' => 'Tetris', 'owner' => $owner];
+        $players = [
+            ['pseudo' => 'Joe',   'gender' => 'M', 'points' => 2500],
+            ['pseudo' => 'Moe',   'gender' => 'M', 'points' => 1230],
+            ['pseudo' => 'Alice', 'gender' => 'F', 'points' => 9001, 'inGame' => $game],
+        ];
+
+        $this->beConstructedWith('name', 'ABC', 'owner');
+
+        $this->filterCollection($players, 'inGame')->shouldYield([$players[2]]);
+    }
+
+    public function it_is_satisfied_in_combo_context(): void
+    {
+        $owner = ['name' => 'ABC', 'based' => 123];
+        $game = ['name' => 'Tetris', 'owner' => $owner];
+        $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230, 'inGame' => $game];
+
+        $this->beConstructedWith('name', 'ABC', 'owner');
+
+        $this->isSatisfiedBy($player, 'inGame')->shouldBe(true);
+    }
 }

--- a/tests/Filter/GreaterOrEqualThanSpec.php
+++ b/tests/Filter/GreaterOrEqualThanSpec.php
@@ -138,4 +138,71 @@ final class GreaterOrEqualThanSpec extends ObjectBehavior
 
         $this->isSatisfiedBy($player)->shouldBe(true);
     }
+
+    public function it_filter_array_collection_in_context(): void
+    {
+        $releaseAt = new \DateTimeImmutable();
+        $game = ['name' => 'Tetris', 'releaseAt' => $releaseAt];
+        $players = [
+            ['pseudo' => 'Joe',   'gender' => 'M', 'points' => 2500],
+            ['pseudo' => 'Moe',   'gender' => 'M', 'points' => 1230],
+            ['pseudo' => 'Alice', 'gender' => 'F', 'points' => 9001, 'inGame' => $game],
+        ];
+
+        $this->beConstructedWith('releaseAt', $releaseAt, 'inGame');
+
+        $this->filterCollection($players)->shouldYield([$players[2]]);
+    }
+
+    public function it_filter_array_collection_in_global_context(): void
+    {
+        $releaseAt = new \DateTimeImmutable();
+        $game = ['name' => 'Tetris', 'releaseAt' => $releaseAt];
+        $players = [
+            ['pseudo' => 'Joe',   'gender' => 'M', 'points' => 2500],
+            ['pseudo' => 'Moe',   'gender' => 'M', 'points' => 1230],
+            ['pseudo' => 'Alice', 'gender' => 'F', 'points' => 9001, 'inGame' => $game],
+        ];
+
+        $this->beConstructedWith('releaseAt', $releaseAt, null);
+
+        $this->filterCollection($players, 'inGame')->shouldYield([$players[2]]);
+    }
+
+    public function it_is_satisfied_in_global_context(): void
+    {
+        $releaseAt = new \DateTimeImmutable();
+        $game = ['name' => 'Tetris', 'releaseAt' => $releaseAt];
+        $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230, 'inGame' => $game];
+
+        $this->beConstructedWith('releaseAt', $releaseAt, null);
+
+        $this->isSatisfiedBy($player, 'inGame')->shouldBe(true);
+    }
+
+    public function it_filter_array_collection_in_combo_context(): void
+    {
+        $owner = ['name' => 'ABC', 'based' => 123];
+        $game = ['name' => 'Tetris', 'owner' => $owner];
+        $players = [
+            ['pseudo' => 'Joe',   'gender' => 'M', 'points' => 2500],
+            ['pseudo' => 'Moe',   'gender' => 'M', 'points' => 1230],
+            ['pseudo' => 'Alice', 'gender' => 'F', 'points' => 9001, 'inGame' => $game],
+        ];
+
+        $this->beConstructedWith('based', 123, 'owner');
+
+        $this->filterCollection($players, 'inGame')->shouldYield([$players[2]]);
+    }
+
+    public function it_is_satisfied_in_combo_context(): void
+    {
+        $owner = ['name' => 'ABC', 'based' => 123];
+        $game = ['name' => 'Tetris', 'owner' => $owner];
+        $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230, 'inGame' => $game];
+
+        $this->beConstructedWith('based', 123, 'owner');
+
+        $this->isSatisfiedBy($player, 'inGame')->shouldBe(true);
+    }
 }

--- a/tests/Filter/GreaterThanSpec.php
+++ b/tests/Filter/GreaterThanSpec.php
@@ -140,4 +140,76 @@ final class GreaterThanSpec extends ObjectBehavior
 
         $this->isSatisfiedBy($player)->shouldBe(true);
     }
+
+    public function it_filter_array_collection_in_context(): void
+    {
+        $now = new \DateTimeImmutable();
+        $releaseAt = new \DateTimeImmutable('+1 day');
+        $game = ['name' => 'Tetris', 'releaseAt' => $releaseAt];
+        $players = [
+            ['pseudo' => 'Joe',   'gender' => 'M', 'points' => 2500],
+            ['pseudo' => 'Moe',   'gender' => 'M', 'points' => 1230],
+            ['pseudo' => 'Alice', 'gender' => 'F', 'points' => 9001, 'inGame' => $game],
+        ];
+
+        $this->beConstructedWith('releaseAt', $now, 'inGame');
+
+        $this->filterCollection($players)->shouldYield([$players[2]]);
+    }
+
+    public function it_filter_array_collection_in_global_context(): void
+    {
+        $now = new \DateTimeImmutable();
+        $releaseAt = new \DateTimeImmutable('+1 day');
+        $game = ['name' => 'Tetris', 'releaseAt' => $releaseAt];
+        $players = [
+            ['pseudo' => 'Joe',   'gender' => 'M', 'points' => 2500],
+            ['pseudo' => 'Moe',   'gender' => 'M', 'points' => 1230],
+            ['pseudo' => 'Alice', 'gender' => 'F', 'points' => 9001, 'inGame' => $game],
+        ];
+
+        $this->beConstructedWith('releaseAt', $now, null);
+
+        $this->filterCollection($players, 'inGame')->shouldYield([$players[2]]);
+    }
+
+    public function it_is_satisfied_in_global_context(): void
+    {
+        $now = new \DateTimeImmutable();
+        $releaseAt = new \DateTimeImmutable('+1 day');
+        $game = ['name' => 'Tetris', 'releaseAt' => $releaseAt];
+        $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230, 'inGame' => $game];
+
+        $this->beConstructedWith('releaseAt', $now, null);
+
+        $this->isSatisfiedBy($player, 'inGame')->shouldBe(true);
+    }
+
+    public function it_filter_array_collection_in_combo_context(): void
+    {
+        $tetrisOwner = ['name' => 'ABC', 'based' => 321];
+        $mahjongOwner = ['name' => 'DEF', 'based' => 123];
+        $tetris = ['name' => 'Tetris', 'owner' => $tetrisOwner];
+        $mahjong = ['name' => 'Mahjong', 'owner' => $mahjongOwner];
+        $players = [
+            ['pseudo' => 'Joe',   'gender' => 'M', 'points' => 2500, 'inGame' => $mahjong],
+            ['pseudo' => 'Moe',   'gender' => 'M', 'points' => 1230, 'inGame' => $mahjong],
+            ['pseudo' => 'Alice', 'gender' => 'F', 'points' => 9001, 'inGame' => $tetris],
+        ];
+
+        $this->beConstructedWith('based', 200, 'owner');
+
+        $this->filterCollection($players, 'inGame')->shouldYield([$players[2]]);
+    }
+
+    public function it_is_satisfied_in_combo_context(): void
+    {
+        $owner = ['name' => 'ABC', 'based' => 123];
+        $game = ['name' => 'Tetris', 'owner' => $owner];
+        $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230, 'inGame' => $game];
+
+        $this->beConstructedWith('based', 100, 'owner');
+
+        $this->isSatisfiedBy($player, 'inGame')->shouldBe(true);
+    }
 }

--- a/tests/Filter/InSpec.php
+++ b/tests/Filter/InSpec.php
@@ -127,4 +127,70 @@ final class InSpec extends ObjectBehavior
 
         $this->isSatisfiedBy($player)->shouldBe(true);
     }
+
+    public function it_filter_array_collection_in_context(): void
+    {
+        $tetris = ['name' => 'Tetris'];
+        $players = [
+            ['pseudo' => 'Joe',   'gender' => 'M', 'points' => 2500],
+            ['pseudo' => 'Moe',   'gender' => 'M', 'points' => 1230],
+            ['pseudo' => 'Alice', 'gender' => 'F', 'points' => 9001, 'inGame' => $tetris],
+        ];
+
+        $this->beConstructedWith('name', ['Mahjong', 'Tetris'], 'inGame');
+
+        $this->filterCollection($players)->shouldYield([$players[2]]);
+    }
+
+    public function it_filter_array_collection_in_global_context(): void
+    {
+        $tetris = ['name' => 'Tetris'];
+        $players = [
+            ['pseudo' => 'Joe',   'gender' => 'M', 'points' => 2500],
+            ['pseudo' => 'Moe',   'gender' => 'M', 'points' => 1230],
+            ['pseudo' => 'Alice', 'gender' => 'F', 'points' => 9001, 'inGame' => $tetris],
+        ];
+
+        $this->beConstructedWith('name', ['Mahjong', 'Tetris'], null);
+
+        $this->filterCollection($players, 'inGame')->shouldYield([$players[2]]);
+    }
+
+    public function it_is_satisfied_in_global_context(): void
+    {
+        $game = ['name' => 'Tetris'];
+        $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230, 'inGame' => $game];
+
+        $this->beConstructedWith('name', ['Mahjong', 'Tetris'], null);
+
+        $this->isSatisfiedBy($player, 'inGame')->shouldBe(true);
+    }
+
+    public function it_filter_array_collection_in_combo_context(): void
+    {
+        $tetrisOwner = ['name' => 'ABC', 'based' => 123];
+        $mahjongOwner = ['name' => 'DEF', 'based' => 321];
+        $tetris = ['name' => 'Tetris', 'owner' => $tetrisOwner];
+        $mahjong = ['name' => 'Mahjong', 'owner' => $mahjongOwner];
+        $players = [
+            ['pseudo' => 'Joe',   'gender' => 'M', 'points' => 2500, 'inGame' => $mahjong],
+            ['pseudo' => 'Moe',   'gender' => 'M', 'points' => 1230, 'inGame' => $mahjong],
+            ['pseudo' => 'Alice', 'gender' => 'F', 'points' => 9001, 'inGame' => $tetris],
+        ];
+
+        $this->beConstructedWith('name', ['ABC', 'GHI'], 'owner');
+
+        $this->filterCollection($players, 'inGame')->shouldYield([$players[2]]);
+    }
+
+    public function it_is_satisfied_in_combo_context(): void
+    {
+        $owner = ['name' => 'ABC', 'based' => 123];
+        $game = ['name' => 'Tetris', 'owner' => $owner];
+        $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230, 'inGame' => $game];
+
+        $this->beConstructedWith('name', ['ABC', 'GHI'], 'owner');
+
+        $this->isSatisfiedBy($player, 'inGame')->shouldBe(true);
+    }
 }

--- a/tests/Filter/IsNotNullSpec.php
+++ b/tests/Filter/IsNotNullSpec.php
@@ -139,4 +139,75 @@ final class IsNotNullSpec extends ObjectBehavior
 
         $this->isSatisfiedBy($player)->shouldBe(true);
     }
+
+    public function it_filter_array_collection_in_context(): void
+    {
+        $releaseAt = new \DateTimeImmutable();
+        $tetris = ['name' => 'Tetris', 'releaseAt' => $releaseAt];
+        $mahjong = ['name' => 'Mahjong', 'releaseAt' => null];
+        $players = [
+            ['pseudo' => 'Joe',   'gender' => 'M', 'points' => 2500, 'inGame' => $mahjong],
+            ['pseudo' => 'Moe',   'gender' => 'M', 'points' => 1230, 'inGame' => $mahjong],
+            ['pseudo' => 'Alice', 'gender' => 'F', 'points' => 9001, 'inGame' => $tetris],
+        ];
+
+        $this->beConstructedWith('releaseAt', 'inGame');
+
+        $this->filterCollection($players)->shouldYield([$players[2]]);
+    }
+
+    public function it_filter_array_collection_in_global_context(): void
+    {
+        $releaseAt = new \DateTimeImmutable();
+        $tetris = ['name' => 'Tetris', 'releaseAt' => $releaseAt];
+        $mahjong = ['name' => 'Mahjong', 'releaseAt' => null];
+        $players = [
+            ['pseudo' => 'Joe',   'gender' => 'M', 'points' => 2500, 'inGame' => $mahjong],
+            ['pseudo' => 'Moe',   'gender' => 'M', 'points' => 1230, 'inGame' => $mahjong],
+            ['pseudo' => 'Alice', 'gender' => 'F', 'points' => 9001, 'inGame' => $tetris],
+        ];
+
+        $this->beConstructedWith('releaseAt', null);
+
+        $this->filterCollection($players, 'inGame')->shouldYield([$players[2]]);
+    }
+
+    public function it_is_satisfied_in_global_context(): void
+    {
+        $releaseAt = new \DateTimeImmutable();
+        $game = ['name' => 'Tetris', 'releaseAt' => $releaseAt];
+        $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230, 'inGame' => $game];
+
+        $this->beConstructedWith('releaseAt', null);
+
+        $this->isSatisfiedBy($player, 'inGame')->shouldBe(true);
+    }
+
+    public function it_filter_array_collection_in_combo_context(): void
+    {
+        $tetrisOwner = ['name' => 'ABC', 'based' => 123];
+        $mahjongOwner = ['name' => 'DEF', 'based' => null];
+        $tetris = ['name' => 'Tetris', 'owner' => $tetrisOwner];
+        $mahjong = ['name' => 'Mahjong', 'owner' => $mahjongOwner];
+        $players = [
+            ['pseudo' => 'Joe',   'gender' => 'M', 'points' => 2500, 'inGame' => $mahjong],
+            ['pseudo' => 'Moe',   'gender' => 'M', 'points' => 1230, 'inGame' => $mahjong],
+            ['pseudo' => 'Alice', 'gender' => 'F', 'points' => 9001, 'inGame' => $tetris],
+        ];
+
+        $this->beConstructedWith('based', 'owner');
+
+        $this->filterCollection($players, 'inGame')->shouldYield([$players[2]]);
+    }
+
+    public function it_is_satisfied_in_combo_context(): void
+    {
+        $owner = ['name' => 'ABC', 'based' => 123];
+        $game = ['name' => 'Tetris', 'owner' => $owner];
+        $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230, 'inGame' => $game];
+
+        $this->beConstructedWith('based', 'owner');
+
+        $this->isSatisfiedBy($player, 'inGame')->shouldBe(true);
+    }
 }

--- a/tests/Filter/IsNullSpec.php
+++ b/tests/Filter/IsNullSpec.php
@@ -137,4 +137,74 @@ final class IsNullSpec extends ObjectBehavior
 
         $this->isSatisfiedBy($player)->shouldBe(true);
     }
+
+    public function it_filter_array_collection_in_context(): void
+    {
+        $releaseAt = new \DateTimeImmutable();
+        $tetris = ['name' => 'Tetris', 'releaseAt' => null];
+        $mahjong = ['name' => 'Mahjong', 'releaseAt' => $releaseAt];
+        $players = [
+            ['pseudo' => 'Joe',   'gender' => 'M', 'points' => 2500, 'inGame' => $mahjong],
+            ['pseudo' => 'Moe',   'gender' => 'M', 'points' => 1230, 'inGame' => $mahjong],
+            ['pseudo' => 'Alice', 'gender' => 'F', 'points' => 9001, 'inGame' => $tetris],
+        ];
+
+        $this->beConstructedWith('releaseAt', 'inGame');
+
+        $this->filterCollection($players)->shouldYield([$players[2]]);
+    }
+
+    public function it_filter_array_collection_in_global_context(): void
+    {
+        $releaseAt = new \DateTimeImmutable();
+        $tetris = ['name' => 'Tetris', 'releaseAt' => null];
+        $mahjong = ['name' => 'Mahjong', 'releaseAt' => $releaseAt];
+        $players = [
+            ['pseudo' => 'Joe',   'gender' => 'M', 'points' => 2500, 'inGame' => $mahjong],
+            ['pseudo' => 'Moe',   'gender' => 'M', 'points' => 1230, 'inGame' => $mahjong],
+            ['pseudo' => 'Alice', 'gender' => 'F', 'points' => 9001, 'inGame' => $tetris],
+        ];
+
+        $this->beConstructedWith('releaseAt', null);
+
+        $this->filterCollection($players, 'inGame')->shouldYield([$players[2]]);
+    }
+
+    public function it_is_satisfied_in_global_context(): void
+    {
+        $game = ['name' => 'Tetris', 'releaseAt' => null];
+        $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230, 'inGame' => $game];
+
+        $this->beConstructedWith('releaseAt', null);
+
+        $this->isSatisfiedBy($player, 'inGame')->shouldBe(true);
+    }
+
+    public function it_filter_array_collection_in_combo_context(): void
+    {
+        $tetrisOwner = ['name' => 'ABC', 'based' => null];
+        $mahjongOwner = ['name' => 'DEF', 'based' => 321];
+        $tetris = ['name' => 'Tetris', 'owner' => $tetrisOwner];
+        $mahjong = ['name' => 'Mahjong', 'owner' => $mahjongOwner];
+        $players = [
+            ['pseudo' => 'Joe',   'gender' => 'M', 'points' => 2500, 'inGame' => $mahjong],
+            ['pseudo' => 'Moe',   'gender' => 'M', 'points' => 1230, 'inGame' => $mahjong],
+            ['pseudo' => 'Alice', 'gender' => 'F', 'points' => 9001, 'inGame' => $tetris],
+        ];
+
+        $this->beConstructedWith('based', 'owner');
+
+        $this->filterCollection($players, 'inGame')->shouldYield([$players[2]]);
+    }
+
+    public function it_is_satisfied_in_combo_context(): void
+    {
+        $owner = ['name' => 'ABC', 'based' => null];
+        $game = ['name' => 'Tetris', 'owner' => $owner];
+        $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230, 'inGame' => $game];
+
+        $this->beConstructedWith('based', 'owner');
+
+        $this->isSatisfiedBy($player, 'inGame')->shouldBe(true);
+    }
 }

--- a/tests/Filter/LessOrEqualThanSpec.php
+++ b/tests/Filter/LessOrEqualThanSpec.php
@@ -138,4 +138,75 @@ final class LessOrEqualThanSpec extends ObjectBehavior
 
         $this->isSatisfiedBy($player)->shouldBe(true);
     }
+
+    public function it_filter_array_collection_in_context(): void
+    {
+        $now = new \DateTimeImmutable();
+        $tetris = ['name' => 'Tetris', 'releaseAt' => new \DateTimeImmutable('-1 day')];
+        $mahjong = ['name' => 'Mahjong', 'releaseAt' => new \DateTimeImmutable('+1 day')];
+        $players = [
+            ['pseudo' => 'Joe',   'gender' => 'M', 'points' => 2500, 'inGame' => $mahjong],
+            ['pseudo' => 'Moe',   'gender' => 'M', 'points' => 1230, 'inGame' => $mahjong],
+            ['pseudo' => 'Alice', 'gender' => 'F', 'points' => 9001, 'inGame' => $tetris],
+        ];
+
+        $this->beConstructedWith('releaseAt', $now, 'inGame');
+
+        $this->filterCollection($players)->shouldYield([$players[2]]);
+    }
+
+    public function it_filter_array_collection_in_global_context(): void
+    {
+        $now = new \DateTimeImmutable();
+        $tetris = ['name' => 'Tetris', 'releaseAt' => new \DateTimeImmutable('-1 day')];
+        $mahjong = ['name' => 'Mahjong', 'releaseAt' => new \DateTimeImmutable('+1 day')];
+        $players = [
+            ['pseudo' => 'Joe',   'gender' => 'M', 'points' => 2500, 'inGame' => $mahjong],
+            ['pseudo' => 'Moe',   'gender' => 'M', 'points' => 1230, 'inGame' => $mahjong],
+            ['pseudo' => 'Alice', 'gender' => 'F', 'points' => 9001, 'inGame' => $tetris],
+        ];
+
+        $this->beConstructedWith('releaseAt', $now, null);
+
+        $this->filterCollection($players, 'inGame')->shouldYield([$players[2]]);
+    }
+
+    public function it_is_satisfied_in_global_context(): void
+    {
+        $releaseAt = new \DateTimeImmutable();
+        $game = ['name' => 'Tetris', 'releaseAt' => $releaseAt];
+        $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230, 'inGame' => $game];
+
+        $this->beConstructedWith('releaseAt', $releaseAt, null);
+
+        $this->isSatisfiedBy($player, 'inGame')->shouldBe(true);
+    }
+
+    public function it_filter_array_collection_in_combo_context(): void
+    {
+        $tetrisOwner = ['name' => 'ABC', 'based' => 123];
+        $mahjongOwner = ['name' => 'DEF', 'based' => 321];
+        $tetris = ['name' => 'Tetris', 'owner' => $tetrisOwner];
+        $mahjong = ['name' => 'Mahjong', 'owner' => $mahjongOwner];
+        $players = [
+            ['pseudo' => 'Joe',   'gender' => 'M', 'points' => 2500, 'inGame' => $mahjong],
+            ['pseudo' => 'Moe',   'gender' => 'M', 'points' => 1230, 'inGame' => $mahjong],
+            ['pseudo' => 'Alice', 'gender' => 'F', 'points' => 9001, 'inGame' => $tetris],
+        ];
+
+        $this->beConstructedWith('based', 200, 'owner');
+
+        $this->filterCollection($players, 'inGame')->shouldYield([$players[2]]);
+    }
+
+    public function it_is_satisfied_in_combo_context(): void
+    {
+        $owner = ['name' => 'ABC', 'based' => 123];
+        $game = ['name' => 'Tetris', 'owner' => $owner];
+        $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230, 'inGame' => $game];
+
+        $this->beConstructedWith('name', 'ABC', 'owner');
+
+        $this->isSatisfiedBy($player, 'inGame')->shouldBe(true);
+    }
 }

--- a/tests/Filter/LessThanSpec.php
+++ b/tests/Filter/LessThanSpec.php
@@ -140,4 +140,76 @@ final class LessThanSpec extends ObjectBehavior
 
         $this->isSatisfiedBy($player)->shouldBe(true);
     }
+
+    public function it_filter_array_collection_in_context(): void
+    {
+        $now = new \DateTimeImmutable();
+        $tetris = ['name' => 'Tetris', 'releaseAt' => new \DateTimeImmutable('-1 day')];
+        $mahjong = ['name' => 'Mahjong', 'releaseAt' => new \DateTimeImmutable('+1 day')];
+        $players = [
+            ['pseudo' => 'Joe',   'gender' => 'M', 'points' => 2500, 'inGame' => $mahjong],
+            ['pseudo' => 'Moe',   'gender' => 'M', 'points' => 1230, 'inGame' => $mahjong],
+            ['pseudo' => 'Alice', 'gender' => 'F', 'points' => 9001, 'inGame' => $tetris],
+        ];
+
+        $this->beConstructedWith('releaseAt', $now, 'inGame');
+
+        $this->filterCollection($players)->shouldYield([$players[2]]);
+    }
+
+    public function it_filter_array_collection_in_global_context(): void
+    {
+        $now = new \DateTimeImmutable();
+        $tetris = ['name' => 'Tetris', 'releaseAt' => new \DateTimeImmutable('-1 day')];
+        $mahjong = ['name' => 'Mahjong', 'releaseAt' => new \DateTimeImmutable('+1 day')];
+        $players = [
+            ['pseudo' => 'Joe',   'gender' => 'M', 'points' => 2500, 'inGame' => $mahjong],
+            ['pseudo' => 'Moe',   'gender' => 'M', 'points' => 1230, 'inGame' => $mahjong],
+            ['pseudo' => 'Alice', 'gender' => 'F', 'points' => 9001, 'inGame' => $tetris],
+        ];
+
+        $this->beConstructedWith('releaseAt', $now, null);
+
+        $this->filterCollection($players, 'inGame')->shouldYield([$players[2]]);
+    }
+
+    public function it_is_satisfied_in_global_context(): void
+    {
+        $now = new \DateTimeImmutable();
+        $releaseAt = new \DateTimeImmutable('-1 day');
+        $game = ['name' => 'Tetris', 'releaseAt' => $releaseAt];
+        $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230, 'inGame' => $game];
+
+        $this->beConstructedWith('releaseAt', $now, null);
+
+        $this->isSatisfiedBy($player, 'inGame')->shouldBe(true);
+    }
+
+    public function it_filter_array_collection_in_combo_context(): void
+    {
+        $tetrisOwner = ['name' => 'ABC', 'based' => 123];
+        $mahjongOwner = ['name' => 'DEF', 'based' => 321];
+        $tetris = ['name' => 'Tetris', 'owner' => $tetrisOwner];
+        $mahjong = ['name' => 'Mahjong', 'owner' => $mahjongOwner];
+        $players = [
+            ['pseudo' => 'Joe',   'gender' => 'M', 'points' => 2500, 'inGame' => $mahjong],
+            ['pseudo' => 'Moe',   'gender' => 'M', 'points' => 1230, 'inGame' => $mahjong],
+            ['pseudo' => 'Alice', 'gender' => 'F', 'points' => 9001, 'inGame' => $tetris],
+        ];
+
+        $this->beConstructedWith('based', 200, 'owner');
+
+        $this->filterCollection($players, 'inGame')->shouldYield([$players[2]]);
+    }
+
+    public function it_is_satisfied_in_combo_context(): void
+    {
+        $owner = ['name' => 'ABC', 'based' => 123];
+        $game = ['name' => 'Tetris', 'owner' => $owner];
+        $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230, 'inGame' => $game];
+
+        $this->beConstructedWith('based', 200, 'owner');
+
+        $this->isSatisfiedBy($player, 'inGame')->shouldBe(true);
+    }
 }

--- a/tests/Filter/LikeSpec.php
+++ b/tests/Filter/LikeSpec.php
@@ -292,4 +292,73 @@ final class LikeSpec extends ObjectBehavior
 
         $this->isSatisfiedBy($player)->shouldBe(true);
     }
+
+    public function it_filter_array_collection_in_context(): void
+    {
+        $tetris = ['name' => 'Tetris'];
+        $mahjong = ['name' => 'Mahjong'];
+        $players = [
+            ['pseudo' => 'Joe',   'gender' => 'M', 'points' => 2500, 'inGame' => $mahjong],
+            ['pseudo' => 'Moe',   'gender' => 'M', 'points' => 1230, 'inGame' => $mahjong],
+            ['pseudo' => 'Alice', 'gender' => 'F', 'points' => 9001, 'inGame' => $tetris],
+        ];
+
+        $this->beConstructedWith('name', 'tr', Like::CONTAINS, 'inGame');
+
+        $this->filterCollection($players)->shouldYield([$players[2]]);
+    }
+
+    public function it_filter_array_collection_in_global_context(): void
+    {
+        $releaseAt = new \DateTimeImmutable();
+        $tetris = ['name' => 'Tetris', 'releaseAt' => null];
+        $mahjong = ['name' => 'Mahjong', 'releaseAt' => $releaseAt];
+        $players = [
+            ['pseudo' => 'Joe',   'gender' => 'M', 'points' => 2500, 'inGame' => $mahjong],
+            ['pseudo' => 'Moe',   'gender' => 'M', 'points' => 1230, 'inGame' => $mahjong],
+            ['pseudo' => 'Alice', 'gender' => 'F', 'points' => 9001, 'inGame' => $tetris],
+        ];
+
+        $this->beConstructedWith('name', 'tr', Like::CONTAINS, null);
+
+        $this->filterCollection($players, 'inGame')->shouldYield([$players[2]]);
+    }
+
+    public function it_is_satisfied_in_global_context(): void
+    {
+        $game = ['name' => 'Tetris'];
+        $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230, 'inGame' => $game];
+
+        $this->beConstructedWith('name', 'tr', Like::CONTAINS, null);
+
+        $this->isSatisfiedBy($player, 'inGame')->shouldBe(true);
+    }
+
+    public function it_filter_array_collection_in_combo_context(): void
+    {
+        $tetrisOwner = ['name' => 'ABC', 'based' => 123];
+        $mahjongOwner = ['name' => 'DEF', 'based' => 321];
+        $tetris = ['name' => 'Tetris', 'owner' => $tetrisOwner];
+        $mahjong = ['name' => 'Mahjong', 'owner' => $mahjongOwner];
+        $players = [
+            ['pseudo' => 'Joe',   'gender' => 'M', 'points' => 2500, 'inGame' => $mahjong],
+            ['pseudo' => 'Moe',   'gender' => 'M', 'points' => 1230, 'inGame' => $mahjong],
+            ['pseudo' => 'Alice', 'gender' => 'F', 'points' => 9001, 'inGame' => $tetris],
+        ];
+
+        $this->beConstructedWith('name', 'BC', Like::CONTAINS, 'owner');
+
+        $this->filterCollection($players, 'inGame')->shouldYield([$players[2]]);
+    }
+
+    public function it_is_satisfied_in_combo_context(): void
+    {
+        $owner = ['name' => 'ABC', 'based' => 123];
+        $game = ['name' => 'Tetris', 'owner' => $owner];
+        $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230, 'inGame' => $game];
+
+        $this->beConstructedWith('name', 'BC', Like::CONTAINS, 'owner');
+
+        $this->isSatisfiedBy($player, 'inGame')->shouldBe(true);
+    }
 }

--- a/tests/Filter/NotEqualsSpec.php
+++ b/tests/Filter/NotEqualsSpec.php
@@ -132,4 +132,72 @@ final class NotEqualsSpec extends ObjectBehavior
 
         $this->isSatisfiedBy($player)->shouldBe(true);
     }
+
+    public function it_filter_array_collection_in_context(): void
+    {
+        $tetris = ['name' => 'Tetris'];
+        $mahjong = ['name' => 'Mahjong'];
+        $players = [
+            ['pseudo' => 'Joe',   'gender' => 'M', 'points' => 2500, 'inGame' => $mahjong],
+            ['pseudo' => 'Moe',   'gender' => 'M', 'points' => 1230, 'inGame' => $mahjong],
+            ['pseudo' => 'Alice', 'gender' => 'F', 'points' => 9001, 'inGame' => $tetris],
+        ];
+
+        $this->beConstructedWith('name', 'Mahjong', 'inGame');
+
+        $this->filterCollection($players)->shouldYield([$players[2]]);
+    }
+
+    public function it_filter_array_collection_in_global_context(): void
+    {
+        $tetris = ['name' => 'Tetris'];
+        $mahjong = ['name' => 'Mahjong'];
+        $players = [
+            ['pseudo' => 'Joe',   'gender' => 'M', 'points' => 2500, 'inGame' => $mahjong],
+            ['pseudo' => 'Moe',   'gender' => 'M', 'points' => 1230, 'inGame' => $mahjong],
+            ['pseudo' => 'Alice', 'gender' => 'F', 'points' => 9001, 'inGame' => $tetris],
+        ];
+
+        $this->beConstructedWith('name', 'Mahjong', null);
+
+        $this->filterCollection($players, 'inGame')->shouldYield([$players[2]]);
+    }
+
+    public function it_is_satisfied_in_global_context(): void
+    {
+        $game = ['name' => 'Tetris'];
+        $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230, 'inGame' => $game];
+
+        $this->beConstructedWith('name', 'Mahjong', null);
+
+        $this->isSatisfiedBy($player, 'inGame')->shouldBe(true);
+    }
+
+    public function it_filter_array_collection_in_combo_context(): void
+    {
+        $tetrisOwner = ['name' => 'ABC', 'based' => 123];
+        $mahjongOwner = ['name' => 'DEF', 'based' => 321];
+        $tetris = ['name' => 'Tetris', 'owner' => $tetrisOwner];
+        $mahjong = ['name' => 'Mahjong', 'owner' => $mahjongOwner];
+        $players = [
+            ['pseudo' => 'Joe',   'gender' => 'M', 'points' => 2500, 'inGame' => $mahjong],
+            ['pseudo' => 'Moe',   'gender' => 'M', 'points' => 1230, 'inGame' => $mahjong],
+            ['pseudo' => 'Alice', 'gender' => 'F', 'points' => 9001, 'inGame' => $tetris],
+        ];
+
+        $this->beConstructedWith('name', 'DEF', 'owner');
+
+        $this->filterCollection($players, 'inGame')->shouldYield([$players[2]]);
+    }
+
+    public function it_is_satisfied_in_combo_context(): void
+    {
+        $owner = ['name' => 'ABC', 'based' => 123];
+        $game = ['name' => 'Tetris', 'owner' => $owner];
+        $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230, 'inGame' => $game];
+
+        $this->beConstructedWith('name', 'DEF', 'owner');
+
+        $this->isSatisfiedBy($player, 'inGame')->shouldBe(true);
+    }
 }

--- a/tests/Logic/AndXSpec.php
+++ b/tests/Logic/AndXSpec.php
@@ -19,9 +19,11 @@ use Doctrine\ORM\QueryBuilder;
 use Happyr\DoctrineSpecification\Filter\Equals;
 use Happyr\DoctrineSpecification\Filter\Filter;
 use Happyr\DoctrineSpecification\Filter\GreaterThan;
+use Happyr\DoctrineSpecification\Filter\LessThan;
 use Happyr\DoctrineSpecification\Logic\AndX;
 use Happyr\DoctrineSpecification\Specification\Specification;
 use PhpSpec\ObjectBehavior;
+use tests\Happyr\DoctrineSpecification\Game;
 use tests\Happyr\DoctrineSpecification\Player;
 
 /**
@@ -190,5 +192,49 @@ final class AndXSpec extends ObjectBehavior
         $player = new Player('Alice', 'F', 9001);
 
         $this->isSatisfiedBy($player)->shouldBe(true);
+    }
+
+    public function it_filter_array_collection_in_context(): void
+    {
+        $this->beConstructedWith(new Equals('name', 'Tetris'), new LessThan('releaseAt', new \DateTimeImmutable()));
+
+        $releaseAt = new \DateTimeImmutable('-1 day');
+        $game = ['name' => 'Tetris', 'releaseAt' => $releaseAt];
+        $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230, 'inGame' => $game];
+
+        $this->filterCollection([$player], 'inGame')->shouldYield([$player]);
+    }
+
+    public function it_filter_object_collection_in_context(): void
+    {
+        $this->beConstructedWith(new Equals('name', 'Tetris'), new LessThan('releaseAt', new \DateTimeImmutable()));
+
+        $releaseAt = new \DateTimeImmutable('-1 day');
+        $game = new Game('Tetris', $releaseAt);
+        $player = new Player('Moe', 'M', 1230, $game);
+
+        $this->filterCollection([$player], 'inGame')->shouldYield([$player]);
+    }
+
+    public function it_is_satisfied_array_collection_in_context(): void
+    {
+        $this->beConstructedWith(new Equals('name', 'Tetris'), new LessThan('releaseAt', new \DateTimeImmutable()));
+
+        $releaseAt = new \DateTimeImmutable('-1 day');
+        $game = ['name' => 'Tetris', 'releaseAt' => $releaseAt];
+        $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230, 'inGame' => $game];
+
+        $this->isSatisfiedBy($player, 'inGame')->shouldBe(true);
+    }
+
+    public function it_is_satisfied_object_collection_in_context(): void
+    {
+        $this->beConstructedWith(new Equals('name', 'Tetris'), new LessThan('releaseAt', new \DateTimeImmutable()));
+
+        $releaseAt = new \DateTimeImmutable('-1 day');
+        $game = new Game('Tetris', $releaseAt);
+        $player = new Player('Moe', 'M', 1230, $game);
+
+        $this->isSatisfiedBy($player, 'inGame')->shouldBe(true);
     }
 }

--- a/tests/Logic/NotSpec.php
+++ b/tests/Logic/NotSpec.php
@@ -21,6 +21,7 @@ use Happyr\DoctrineSpecification\Filter\Filter;
 use Happyr\DoctrineSpecification\Logic\Not;
 use Happyr\DoctrineSpecification\Specification\Specification;
 use PhpSpec\ObjectBehavior;
+use tests\Happyr\DoctrineSpecification\Game;
 use tests\Happyr\DoctrineSpecification\Player;
 
 /**
@@ -156,5 +157,45 @@ final class NotSpec extends ObjectBehavior
         $player = new Player('Alice', 'F', 9001);
 
         $this->isSatisfiedBy($player)->shouldBe(true);
+    }
+
+    public function it_filter_array_collection_in_context(): void
+    {
+        $this->beConstructedWith(new Equals('name', 'Mahjong'));
+
+        $game = ['name' => 'Tetris'];
+        $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230, 'inGame' => $game];
+
+        $this->filterCollection([$player], 'inGame')->shouldYield([$player]);
+    }
+
+    public function it_filter_object_collection_in_context(): void
+    {
+        $this->beConstructedWith(new Equals('name', 'Mahjong'));
+
+        $game = new Game('Tetris');
+        $player = new Player('Moe', 'M', 1230, $game);
+
+        $this->filterCollection([$player], 'inGame')->shouldYield([$player]);
+    }
+
+    public function it_is_satisfied_array_collection_in_context(): void
+    {
+        $this->beConstructedWith(new Equals('name', 'Mahjong'));
+
+        $game = ['name' => 'Tetris'];
+        $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230, 'inGame' => $game];
+
+        $this->isSatisfiedBy($player, 'inGame')->shouldBe(true);
+    }
+
+    public function it_is_satisfied_object_collection_in_context(): void
+    {
+        $this->beConstructedWith(new Equals('name', 'Mahjong'));
+
+        $game = new Game('Tetris');
+        $player = new Player('Moe', 'M', 1230, $game);
+
+        $this->isSatisfiedBy($player, 'inGame')->shouldBe(true);
     }
 }

--- a/tests/Logic/OrXSpec.php
+++ b/tests/Logic/OrXSpec.php
@@ -22,6 +22,7 @@ use Happyr\DoctrineSpecification\Filter\GreaterThan;
 use Happyr\DoctrineSpecification\Logic\OrX;
 use Happyr\DoctrineSpecification\Specification\Specification;
 use PhpSpec\ObjectBehavior;
+use tests\Happyr\DoctrineSpecification\Game;
 use tests\Happyr\DoctrineSpecification\Player;
 
 /**
@@ -198,5 +199,49 @@ final class OrXSpec extends ObjectBehavior
         $player = new Player('Alice', 'F', 9001);
 
         $this->isSatisfiedBy($player)->shouldBe(true);
+    }
+
+    public function it_filter_array_collection_in_context(): void
+    {
+        $this->beConstructedWith(new Equals('name', 'Tetris'), new GreaterThan('releaseAt', new \DateTimeImmutable()));
+
+        $releaseAt = new \DateTimeImmutable('-1 day');
+        $game = ['name' => 'Tetris', 'releaseAt' => $releaseAt];
+        $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230, 'inGame' => $game];
+
+        $this->filterCollection([$player], 'inGame')->shouldYield([$player]);
+    }
+
+    public function it_filter_object_collection_in_context(): void
+    {
+        $this->beConstructedWith(new Equals('name', 'Tetris'), new GreaterThan('releaseAt', new \DateTimeImmutable()));
+
+        $releaseAt = new \DateTimeImmutable('-1 day');
+        $game = new Game('Tetris', $releaseAt);
+        $player = new Player('Moe', 'M', 1230, $game);
+
+        $this->filterCollection([$player], 'inGame')->shouldYield([$player]);
+    }
+
+    public function it_is_satisfied_array_collection_in_context(): void
+    {
+        $this->beConstructedWith(new Equals('name', 'Tetris'), new GreaterThan('releaseAt', new \DateTimeImmutable()));
+
+        $releaseAt = new \DateTimeImmutable('-1 day');
+        $game = ['name' => 'Tetris', 'releaseAt' => $releaseAt];
+        $player = ['pseudo' => 'Moe', 'gender' => 'M', 'points' => 1230, 'inGame' => $game];
+
+        $this->isSatisfiedBy($player, 'inGame')->shouldBe(true);
+    }
+
+    public function it_is_satisfied_object_collection_in_context(): void
+    {
+        $this->beConstructedWith(new Equals('name', 'Tetris'), new GreaterThan('releaseAt', new \DateTimeImmutable()));
+
+        $releaseAt = new \DateTimeImmutable('-1 day');
+        $game = new Game('Tetris', $releaseAt);
+        $player = new Player('Moe', 'M', 1230, $game);
+
+        $this->isSatisfiedBy($player, 'inGame')->shouldBe(true);
     }
 }


### PR DESCRIPTION
Allow use context in `Satisfiable::filterCollection()` and `Satisfiable::isSatisfiedBy()` methods.