### PR TITLE
Сreate SelectNew query modifier for use NEW Operator Syntax

### DIFF
--- a/src/Query/SelectNew.php
+++ b/src/Query/SelectNew.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This file is part of the Happyr Doctrine Specification package.
+ *
+ * (c) Tobias Nyholm <tobias@happyr.com>
+ *     Kacper Gunia <kacper@gunia.me>
+ *     Peter Gribanov <info@peter-gribanov.ru>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Happyr\DoctrineSpecification\Query;
+
+use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Operand\ArgumentToOperandConverter;
+use Happyr\DoctrineSpecification\Operand\Operand;
+
+/**
+ * Using the NEW operator you can construct Data Transfer Objects (DTOs) directly from DQL queries.
+ */
+final class SelectNew implements QueryModifier
+{
+    /**
+     * @var string
+     */
+    private $class;
+
+    /**
+     * @var Operand[]|mixed[]
+     */
+    private $arguments;
+
+    /**
+     * @param string        $class
+     * @param Operand|mixed ...$arguments
+     *
+     * @phpstan-param class-string $class
+     */
+    public function __construct(string $class, ...$arguments)
+    {
+        $this->class = $class;
+        $this->arguments = $arguments;
+    }
+
+    /**
+     * @param QueryBuilder $qb
+     * @param string       $context
+     */
+    public function modify(QueryBuilder $qb, string $context): void
+    {
+        $arguments = [];
+        foreach (ArgumentToOperandConverter::convert($this->arguments) as $argument) {
+            $arguments[] = $argument->transform($qb, $context);
+        }
+
+        $qb->select(sprintf('NEW %s(%s)', $this->class, implode(', ', $arguments)));
+    }
+}

--- a/src/Spec.php
+++ b/src/Spec.php
@@ -66,6 +66,7 @@ use Happyr\DoctrineSpecification\Query\Selection\SelectAs;
 use Happyr\DoctrineSpecification\Query\Selection\SelectEntity;
 use Happyr\DoctrineSpecification\Query\Selection\SelectHiddenAs;
 use Happyr\DoctrineSpecification\Query\Selection\Selection;
+use Happyr\DoctrineSpecification\Query\SelectNew;
 use Happyr\DoctrineSpecification\Query\Slice;
 use Happyr\DoctrineSpecification\Result\AsArray;
 use Happyr\DoctrineSpecification\Result\AsScalar;
@@ -271,6 +272,19 @@ class Spec
     public static function addSelect(...$fields): AddSelect
     {
         return new AddSelect(...$fields);
+    }
+
+    /**
+     * @param string        $class
+     * @param Operand|mixed ...$arguments
+     *
+     * @phpstan-param class-string $class
+     *
+     * @return SelectNew
+     */
+    public static function selectNew(string $class, ...$arguments): SelectNew
+    {
+        return new SelectNew($class, ...$arguments);
     }
 
     /**

--- a/tests/Query/AddSelectSpec.php
+++ b/tests/Query/AddSelectSpec.php
@@ -35,7 +35,7 @@ final class AddSelectSpec extends ObjectBehavior
         $this->shouldBeAnInstanceOf(AddSelect::class);
     }
 
-    public function it_is_a_specification(): void
+    public function it_is_a_query_modifier(): void
     {
         $this->shouldHaveType(QueryModifier::class);
     }

--- a/tests/Query/IndexBySpec.php
+++ b/tests/Query/IndexBySpec.php
@@ -33,7 +33,7 @@ final class IndexBySpec extends ObjectBehavior
         $this->beConstructedWith($this->field, null);
     }
 
-    public function it_is_a_result_modifier(): void
+    public function it_is_a_query_modifier(): void
     {
         $this->shouldBeAnInstanceOf(QueryModifier::class);
     }

--- a/tests/Query/InnerJoinSpec.php
+++ b/tests/Query/InnerJoinSpec.php
@@ -29,7 +29,7 @@ final class InnerJoinSpec extends ObjectBehavior
         $this->beConstructedWith('user', 'authUser', null);
     }
 
-    public function it_is_a_specification(): void
+    public function it_is_a_query_modifier(): void
     {
         $this->shouldHaveType(QueryModifier::class);
     }

--- a/tests/Query/JoinSpec.php
+++ b/tests/Query/JoinSpec.php
@@ -29,7 +29,7 @@ final class JoinSpec extends ObjectBehavior
         $this->beConstructedWith('user', 'authUser', null);
     }
 
-    public function it_is_a_specification(): void
+    public function it_is_a_query_modifier(): void
     {
         $this->shouldHaveType(QueryModifier::class);
     }

--- a/tests/Query/LeftJoinSpec.php
+++ b/tests/Query/LeftJoinSpec.php
@@ -29,7 +29,7 @@ final class LeftJoinSpec extends ObjectBehavior
         $this->beConstructedWith('user', 'authUser', null);
     }
 
-    public function it_is_a_specification(): void
+    public function it_is_a_query_modifier(): void
     {
         $this->shouldHaveType(QueryModifier::class);
     }

--- a/tests/Query/SelectNewSpec.php
+++ b/tests/Query/SelectNewSpec.php
@@ -1,0 +1,93 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This file is part of the Happyr Doctrine Specification package.
+ *
+ * (c) Tobias Nyholm <tobias@happyr.com>
+ *     Kacper Gunia <kacper@gunia.me>
+ *     Peter Gribanov <info@peter-gribanov.ru>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace tests\Happyr\DoctrineSpecification\Query;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Operand\Addition;
+use Happyr\DoctrineSpecification\Operand\Field;
+use Happyr\DoctrineSpecification\Operand\Value;
+use Happyr\DoctrineSpecification\Query\QueryModifier;
+use Happyr\DoctrineSpecification\Query\SelectNew;
+use PhpSpec\ObjectBehavior;
+use tests\Happyr\DoctrineSpecification\Player;
+
+/**
+ * @mixin SelectNew
+ */
+final class SelectNewSpec extends ObjectBehavior
+{
+    public function let(): void
+    {
+        $this->beConstructedWith(Player::class);
+    }
+
+    public function it_is_a_select_new(): void
+    {
+        $this->shouldBeAnInstanceOf(SelectNew::class);
+    }
+
+    public function it_is_a_query_modifier(): void
+    {
+        $this->shouldHaveType(QueryModifier::class);
+    }
+
+    public function it_select_empty_object(QueryBuilder $qb): void
+    {
+        $qb->select(sprintf('NEW %s()', Player::class))->shouldBeCalled();
+
+        $this->modify($qb, 'a');
+    }
+
+    public function it_select_with_field(QueryBuilder $qb): void
+    {
+        $this->beConstructedWith(Player::class, 'pseudo');
+
+        $qb->select(sprintf('NEW %s(a.pseudo)', Player::class))->shouldBeCalled();
+
+        $this->modify($qb, 'a');
+    }
+
+    public function it_select_with_field_and_value(QueryBuilder $qb, ArrayCollection $parameters): void
+    {
+        $this->beConstructedWith(Player::class, 'pseudo', 'F');
+
+        $qb->getParameters()->willReturn($parameters);
+        $parameters->count()->willReturn(10);
+
+        $qb->setParameter('comparison_10', 'F', null)->shouldBeCalled();
+        $qb->select(sprintf('NEW %s(a.pseudo, :comparison_10)', Player::class))->shouldBeCalled();
+
+        $this->modify($qb, 'a');
+    }
+
+    public function it_select_with_operands(QueryBuilder $qb, ArrayCollection $parameters): void
+    {
+        $this->beConstructedWith(
+            Player::class,
+            new Field('pseudo'),
+            new Value('F'),
+            new Addition(new Field('foo'), new Field('bar'))
+        );
+
+        $qb->getParameters()->willReturn($parameters);
+        $parameters->count()->willReturn(10);
+
+        $qb->setParameter('comparison_10', 'F', null)->shouldBeCalled();
+        $qb->select(sprintf('NEW %s(a.pseudo, :comparison_10, (a.foo + a.bar))', Player::class))->shouldBeCalled();
+
+        $this->modify($qb, 'a');
+    }
+}

--- a/tests/Query/SelectSpec.php
+++ b/tests/Query/SelectSpec.php
@@ -35,7 +35,7 @@ final class SelectSpec extends ObjectBehavior
         $this->shouldBeAnInstanceOf(Select::class);
     }
 
-    public function it_is_a_specification(): void
+    public function it_is_a_query_modifier(): void
     {
         $this->shouldHaveType(QueryModifier::class);
     }

--- a/tests/Query/SliceSpec.php
+++ b/tests/Query/SliceSpec.php
@@ -34,7 +34,7 @@ final class SliceSpec extends ObjectBehavior
         $this->beConstructedWith($this->sliceSize, 0);
     }
 
-    public function it_is_a_specification(): void
+    public function it_is_a_query_modifier(): void
     {
         $this->shouldHaveType(QueryModifier::class);
     }


### PR DESCRIPTION
[NEW Operator Syntax](https://www.doctrine-project.org/projects/doctrine-orm/en/2.7/reference/dql-doctrine-query-language.html#new-operator-syntax)

Using the `NEW` operator you can construct Data Transfer Objects (DTOs) directly from DQL queries.

* When using `SELECT NEW` you don't need to specify a mapped entity.
* You can specify any PHP class, it only requires that the constructor of this class matches the `NEW` statement.
* This approach involves determining exactly which columns you really need, and instantiating a data-transfer object that contains a constructor with those arguments.

```php
class CustomerDTO
{
    public function __construct($name, $email, $city, $value = null)
    {
        // Bind values to the object properties.
    }
}
```

```php
// SELECT NEW CustomerDTO(customer.name, email.email, address.city, SUM(orders.value)) FROM Customer customer JOIN customer.email email JOIN customer.address address JOIN customer.orders orders GROUP BY customer.id
$spec = Spec::andX(
    Spec::selectNew(
        CustomerDTO::class,
        Spec::field('name'),
        Spec::field('email', 'email'),
        Spec::field('city', 'address'),
        Spec::SUM(Spec::field('value', 'orders')),
    ),
    Spec::groupBy('id'),
);

// array of CustomerDTO
$users = $rep->match($spec);
```