### PR TITLE
Define JOIN before using the new alias from it

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -363,6 +363,26 @@
   Spec::SUM('field_name');
   ```
 
+* Define `Spec::leftJoin()`, `Spec::innerJoin()` and `Spec::join()` before using the new alias from it.
+
+  Before:
+
+  ```php
+  $spec = Spec::andX(
+      Spec::select(Spec::selectEntity('person')),
+      Spec::leftJoin('person', 'person')
+  );
+  ```
+
+  After:
+
+  ```php
+  $spec = Spec::andX(
+      Spec::leftJoin('person', 'person'),
+      Spec::select(Spec::selectEntity('person'))
+  );
+  ```
+
 # Upgrade from 1.0 to 1.1
 
 * No BC breaks


### PR DESCRIPTION
Define `Spec::leftJoin()`, `Spec::innerJoin()` and `Spec::join()` before using the new alias from it.

Before:

```php
$spec = Spec::andX(
    Spec::select(Spec::selectEntity('person')),
    Spec::leftJoin('person', 'person')
);
```

After:

```php
$spec = Spec::andX(
    Spec::leftJoin('person', 'person'),
    Spec::select(Spec::selectEntity('person'))
);
```

Otherwise, you can get a collision.

> An exception has been thrown during the rendering of a template ("[Semantical Error] line 0, col 171 near 'person WHERE': Error: 'person' is already defined.").

DQL

```sql
SELECT root, person FROM MyEntity root INNER JOIN root.person person LEFT JOIN root.person person
```