### PR TITLE
Not use BaseSpecification::getNestedContext() method

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -123,8 +123,7 @@
   );
   ```
 
-* The `BaseSpecification::getNestedContext()` method was added and behavior of the `BaseSpecification::getContext()`
-  method was changed.
+* Changed behavior of DQL aliases to use context.
 
   Before:
 
@@ -219,7 +218,7 @@
        */
       protected function getSpec()
       {
-          return new ContestantPublished($this->getNestedContext('contestant'));
+          return new ContestantPublished('contestant');
       }
   }
 
@@ -246,7 +245,7 @@
       {
           return Spec::orX(
               Spec::eq('permission', Permission::approved()->value()),
-              Spec::not(new ContestRequireModeration($this->getNestedContext('contest')))
+              Spec::not(new ContestRequireModeration('contest'))
           );
       }
   }

--- a/docs/1-creatingSpecs.md
+++ b/docs/1-creatingSpecs.md
@@ -148,7 +148,7 @@ final class PublishedQuestionnaires extends BaseSpecification
      */
     protected function getSpec()
     {
-        return new ContestantPublished($this->getNestedContext('contestant'));
+        return new ContestantPublished('contestant');
     }
 }
 
@@ -174,8 +174,8 @@ final class JoinedContestant extends BaseSpecification
     protected function getSpec()
     {
         return Spec::andX(
-            new UserActivated($this->getNestedContext('user')),
-            new ContestPublished($this->getNestedContext('contest'))
+            new UserActivated('user'),
+            new ContestPublished('contest')
         );
     }
 }
@@ -211,7 +211,7 @@ final class ContestantApproved extends BaseSpecification
     {
         return Spec::orX(
             Spec::eq('permission', Permission::approved()->value()),
-            Spec::not(new ContestRequireModeration($this->getNestedContext('contest')))
+            Spec::not(new ContestRequireModeration('contest'))
         );
     }
 }


### PR DESCRIPTION
Using of `BaseSpecification::getNestedContext()` can duplicate context.

**Example:**

```php
final class UserActivated extends BaseSpecification
{
    protected function getSpec()
    {
        return new Equals('state', State::active(), State::class, new StateType());
    }
}

final class ContestPublished extends BaseSpecification
{

    protected function getSpec()
    {
        return Spec::eq('enabled', true);
    }
}

final class JoinedContestant extends BaseSpecification
{
    protected function getSpec()
    {
        return Spec::andX(
            new UserActivated($this->getNestedContext('user')),
            new ContestPublished($this->getNestedContext('contest')),
        );
    }
}

$this->rep->match(new JoinedContestant('contestant'));
```

In this example as result used `root.contestant.contestant.user` and `root.contestant.contestant.contest` context. The `contestant` context has been added twice by `BaseSpecification::getNestedContext()` in `JoinedContestant` spec and `BaseSpecification::getContext()` in [`BaseSpecification::getFilter()`](https://github.com/Happyr/Doctrine-Specification/blob/d3ccec5288f54f8b20047f715c239ad595b9c9ca/src/Specification/BaseSpecification.php#L51).

**Result DQL:**

```sql
SELECT
    root
FROM
    Questionnaire root
INNER JOIN
    root.contestant contestant
INNER JOIN
    contestant.contestant contestant603e377bae24a
INNER JOIN
    contestant603e377bae24a.user user
INNER JOIN
    contestant603e377bae24a.contest contest
WHERE
    user.state = :comparison_0 AND
    contest.enabled = :comparison_1
```

To fix the problem, you should stop using the `BaseSpecification::getNestedContext()` method.

```php
final class JoinedContestant extends BaseSpecification
{
    protected function getSpec()
    {
        return Spec::andX(
            new UserActivated('user'),
            new ContestPublished('contest'),
        );
    }
}
```

**Result DQL:**

```sql
SELECT
    root
FROM
    Questionnaire root
INNER JOIN
    root.contestant contestant
INNER JOIN
    contestant.user user
INNER JOIN
    contestant.contest contest
WHERE
    user.state = :comparison_0 AND
    contest.enabled = :comparison_1
```