### PR TITLE
Prefer to use default_repository_class instead of repository_factory

### DIFF
--- a/docs/0-0-symfony.md
+++ b/docs/0-0-symfony.md
@@ -3,7 +3,7 @@
 ## Replacing the default repository type
 
 Replacing Doctrine's default repository type with `Happyr\DoctrineSpecification\Repository\EntitySpecificationRepository` is easy
-in Symfony. The doctrine bundle provides a place in configuration to specify the new type.
+in Symfony. The Doctrine bundle provides a place in configuration to specify the new type.
 
 ```yml
 # app/config/config.yml

--- a/docs/0-0-symfony.md
+++ b/docs/0-0-symfony.md
@@ -6,8 +6,8 @@ Replacing Doctrine's default repository type with `Happyr\DoctrineSpecification\
 in Symfony. The doctrine bundle provides a place in configuration to specify the new type.
 
 ```yml
-// app/config/config.yml
+# app/config/config.yml
 doctrine:
     orm:
-        default_repository_class: Happyr\DoctrineSpecification\Repository\EntitySpecificationRepository
+        default_repository_class: 'Happyr\DoctrineSpecification\Repository\EntitySpecificationRepository'
 ```

--- a/docs/0-1-zend1.md
+++ b/docs/0-1-zend1.md
@@ -9,5 +9,5 @@ A basic implementation is provided with `Happyr\DoctrineSpecification\Repository
 
 ```php
 // During Doctrine configuration
-$config->setDefaultRepositoryClassName(EntitySpecificationRepository::class);
+$config->setDefaultRepositoryClassName(\Happyr\DoctrineSpecification\Repository\EntitySpecificationRepository::class);
 ```

--- a/docs/0-1-zend1.md
+++ b/docs/0-1-zend1.md
@@ -1,13 +1,13 @@
-# Integrating with frameworks - Zend 1
+# Integrating with frameworks - Zend Framework 1
 
 ## Replacing the default repository type
 
 Doctrine integration with Zend Framework 1 is done manually. However, replacing the default repository type is still
 simple. In the bootstrap (or wherever Doctrine is configured in the system in question), use Doctrine configurations
-`setRepositoryFactory` method and provide an implementation of `Doctrine\ORM\Repository\RepositoryFactory`. A basic
-implementation is provided with `Happyr\DoctrineSpecification\Repository\RepositoryFactory`.
+`setDefaultRepositoryClassName` method and provide an implementation of `Doctrine\Common\Persistence\ObjectRepository`.
+A basic implementation is provided with `Happyr\DoctrineSpecification\Repository\EntitySpecificationRepository`.
 
 ```php
-// During doctrine configuration
-$config->setRepositoryFactory(new \Happyr\DoctrineSpecification\Repository\RepositoryFactory());
+// During Doctrine configuration
+$config->setDefaultRepositoryClassName(EntitySpecificationRepository::class);
 ```

--- a/docs/0-2-zend2.md
+++ b/docs/0-2-zend2.md
@@ -8,10 +8,14 @@ configuration options for the repository. To replace the default repository type
 
 ```php
 // Application configuration
-'doctrine' => [
-    'configuration' => [
-        'orm_default' => [
-            'default_repository_class' => EntitySpecificationRepository::class,
+use Happyr\DoctrineSpecification\Repository\EntitySpecificationRepository;
+
+return [
+    'doctrine' => [
+        'configuration' => [
+            'orm_default' => [
+                'default_repository_class' => EntitySpecificationRepository::class,
+            ],
         ],
     ],
 ];

--- a/docs/0-2-zend2.md
+++ b/docs/0-2-zend2.md
@@ -1,23 +1,17 @@
-# Integrating with frameworks - Zend 2
+# Integrating with frameworks - Zend Framework 2 and 3
 
 ## Replacing the default repository type
 
 Doctrine integration with Zend Framework 2 can be achieved using the `DoctrineORM` bundle. This bundle contains
-configuration options for the repository factory. To replace the default repository type, provide a factory creating
-an instance of `Happyr\DoctrineSpecification\Repository\EntitySpecificationRepository` and any necessary configuration options.
+configuration options for the repository. To replace the default repository type, provide a class name of
+`Happyr\DoctrineSpecification\Repository\EntitySpecificationRepository`.
 
 ```php
 // Application configuration
 'doctrine' => [
     'configuration' => [
         'orm_default' => [
-            'repository_factory' => 'happyr_doctrinespecification_repository',
-        ],
-    ],
-
-    'service_manager' => [
-        'services' => [
-            'happyr_doctrinespecification_repository' => new Happyr\DoctrineSpecification\Repository\RepositoryFactory(),
+            'default_repository_class' => EntitySpecificationRepository::class,
         ],
     ],
 ];

--- a/docs/0-3-laravel.md
+++ b/docs/0-3-laravel.md
@@ -2,12 +2,18 @@
 
 ## Replacing the default repository type
 
-If you're choosing to use Doctrine with Laravel, there are some common Doctrine integration packages, however only some of them allow configuration of the default repository type.
+Replacing Doctrine's default repository type with `Happyr\DoctrineSpecification\Repository\EntitySpecificationRepository`
+is easy in Laravel. The Doctrine bundle provides a place in configuration to specify the new type.
 
-### atrauzzi/laravel-doctrine
+```php
+// doctrine.php
+use Happyr\DoctrineSpecification\Repository\EntitySpecificationRepository;
 
-For this package, in its configuration settings, set the `defaultRepository` setting to `Happyr\DoctrineSpecification\Repository\EntitySpecificationRepository`
-
-###  mitchellvanw/laravel-doctrine
-
-For this package, in its configuration settings, set the `repository` setting to `Happyr\DoctrineSpecification\Repository\EntitySpecificationRepository`
+return [
+    'managers' => [
+        'default' => [
+            'repository' => EntitySpecificationRepository::class,
+        ],
+    ],
+];
+```

--- a/docs/0-usage.md
+++ b/docs/0-usage.md
@@ -41,7 +41,7 @@ class MyRepository extends ServiceEntityRepository
 
 Also make sure that the default repository is changed. If you haven't created a repository class in your source
 then you will have to tell `$this->em->getRepository('xxx')` to return a instance of `Happyr\DoctrineSpecification\Repository\EntitySpecificationRepository`.
-See instructions for [Laravel](0-3-laravel.md), [Symfony2](0-0-symfony.md), [Zend1](0-1-zend1.md) and [Zend2](0-2-zend2.md).
+See instructions for [Laravel](0-3-laravel.md), [Symfony](0-0-symfony.md), [Zend 1](0-1-zend1.md), [Zend 2](0-2-zend2.md), [Zend 3](0-2-zend2.md).
 
 Then you may start to create your specifications. Put them in `Acme\DemoBundle\Entity\Spec`. Lets start with a simple one:
 

--- a/src/DBALTypesResolver.php
+++ b/src/DBALTypesResolver.php
@@ -19,7 +19,7 @@ use Doctrine\DBAL\Types\Type;
 final class DBALTypesResolver
 {
     /**
-     * The map of supported doctrine mapping types.
+     * The map of supported Doctrine mapping types.
      *
      * @var array<string, string>
      */


### PR DESCRIPTION
Prefer to use `default_repository_class` instead of `repository_factory`.
Update documentation for #297

## Symfony

```yml
# app/config/config.yml
doctrine:
    orm:
        default_repository_class: 'Happyr\DoctrineSpecification\Repository\EntitySpecificationRepository'
```

## Laravel

```php
// doctrine.php
use Happyr\DoctrineSpecification\Repository\EntitySpecificationRepository;

return [
    'managers' => [
        'default' => [
            'repository' => EntitySpecificationRepository::class,
        ],
    ],
];
```

## Zend Framework 2 and 3

```php
// Application configuration
use Happyr\DoctrineSpecification\Repository\EntitySpecificationRepository;

return [
    'doctrine' => [
        'configuration' => [
            'orm_default' => [
                'default_repository_class' => EntitySpecificationRepository::class,
            ],
        ],
    ],
];
```

## Zend Framework 1

```php
// During Doctrine configuration
$config->setDefaultRepositoryClassName(\Happyr\DoctrineSpecification\Repository\EntitySpecificationRepository::class);
```