### PR TITLE
Wrap NoResultException Doctrine exception in EntitySpecificationRepositoryTrait

### DIFF
--- a/src/Operand/PlatformFunction/Executor/IdentityExecutor.php
+++ b/src/Operand/PlatformFunction/Executor/IdentityExecutor.php
@@ -19,7 +19,7 @@ use Happyr\DoctrineSpecification\Exception\OperandNotExecuteException;
 final class IdentityExecutor
 {
     /**
-     * @throw OperandNotExecuteException
+     * @throws OperandNotExecuteException
      */
     public function __invoke(): void
     {

--- a/src/Operand/PlatformFunction/Executor/PlatformFunctionExecutorRegistry.php
+++ b/src/Operand/PlatformFunction/Executor/PlatformFunctionExecutorRegistry.php
@@ -39,7 +39,7 @@ final class PlatformFunctionExecutorRegistry
      * @param string $functionName
      * @param mixed  ...$arguments
      *
-     * @throw PlatformFunctionExecutorException
+     * @throws PlatformFunctionExecutorException
      *
      * @return mixed
      */
@@ -70,7 +70,7 @@ final class PlatformFunctionExecutorRegistry
      * @param string   $functionName
      * @param callable $executor
      *
-     * @throw PlatformFunctionExecutorException
+     * @throws PlatformFunctionExecutorException
      */
     public function register(string $functionName, callable $executor): void
     {
@@ -89,7 +89,7 @@ final class PlatformFunctionExecutorRegistry
      * @param string   $functionName
      * @param callable $executor
      *
-     * @throw PlatformFunctionExecutorException
+     * @throws PlatformFunctionExecutorException
      */
     public function override(string $functionName, callable $executor): void
     {

--- a/src/Repository/EntitySpecificationRepositoryInterface.php
+++ b/src/Repository/EntitySpecificationRepositoryInterface.php
@@ -17,6 +17,8 @@ namespace Happyr\DoctrineSpecification\Repository;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Exception\NonUniqueResultException;
+use Happyr\DoctrineSpecification\Exception\NoResultException;
 use Happyr\DoctrineSpecification\Filter\Filter;
 use Happyr\DoctrineSpecification\Query\QueryModifier;
 use Happyr\DoctrineSpecification\Result\ResultModifier;
@@ -42,8 +44,8 @@ interface EntitySpecificationRepositoryInterface
      * @param Filter|QueryModifier $specification
      * @param ResultModifier|null  $modifier
      *
-     * @throw Exception\NonUniqueException  If more than one result is found
-     * @throw Exception\NoResultException   If no results found
+     * @throws NonUniqueResultException If more than one result is found
+     * @throws NoResultException        If no results found
      *
      * @return mixed
      */
@@ -55,7 +57,7 @@ interface EntitySpecificationRepositoryInterface
      * @param Filter|QueryModifier $specification
      * @param ResultModifier|null  $modifier
      *
-     * @throw Exception\NonUniqueException  If more than one result is found
+     * @throws NonUniqueResultException If more than one result is found
      *
      * @return mixed|null
      */
@@ -67,8 +69,8 @@ interface EntitySpecificationRepositoryInterface
      * @param Filter|QueryModifier $specification
      * @param ResultModifier|null  $modifier
      *
-     * @throw Exception\NonUniqueException  If more than one result is found
-     * @throw Exception\NoResultException   If no results found
+     * @throws NonUniqueResultException If more than one result is found
+     * @throws NoResultException        If no results found
      *
      * @return mixed
      */
@@ -80,8 +82,7 @@ interface EntitySpecificationRepositoryInterface
      * @param Filter|QueryModifier $specification
      * @param ResultModifier|null  $modifier
      *
-     * @throw Exception\NonUniqueException  If more than one result is found
-     * @throw Exception\NoResultException   If no results found
+     * @throws NoResultException If no results found
      *
      * @return mixed
      */

--- a/src/Repository/EntitySpecificationRepositoryTrait.php
+++ b/src/Repository/EntitySpecificationRepositoryTrait.php
@@ -56,8 +56,8 @@ trait EntitySpecificationRepositoryTrait
      * @param Filter|QueryModifier $specification
      * @param ResultModifier|null  $modifier
      *
-     * @throw Exception\NonUniqueException If more than one result is found
-     * @throw Exception\NoResultException  If no results found
+     * @throws NonUniqueResultException If more than one result is found
+     * @throws NoResultException        If no results found
      *
      * @return mixed
      */
@@ -80,7 +80,7 @@ trait EntitySpecificationRepositoryTrait
      * @param Filter|QueryModifier $specification
      * @param ResultModifier|null  $modifier
      *
-     * @throw Exception\NonUniqueException If more than one result is found
+     * @throws NonUniqueResultException If more than one result is found
      *
      * @return mixed|null
      */
@@ -99,8 +99,8 @@ trait EntitySpecificationRepositoryTrait
      * @param Filter|QueryModifier $specification
      * @param ResultModifier|null  $modifier
      *
-     * @throw Exception\NonUniqueException If more than one result is found
-     * @throw Exception\NoResultException  If no results found
+     * @throws NonUniqueResultException If more than one result is found
+     * @throws NoResultException        If no results found
      *
      * @return mixed
      */
@@ -123,7 +123,7 @@ trait EntitySpecificationRepositoryTrait
      * @param Filter|QueryModifier $specification
      * @param ResultModifier|null  $modifier
      *
-     * @throw Exception\NoResultException If no results found
+     * @throws NoResultException If no results found
      *
      * @return mixed
      */

--- a/src/Repository/EntitySpecificationRepositoryTrait.php
+++ b/src/Repository/EntitySpecificationRepositoryTrait.php
@@ -56,8 +56,8 @@ trait EntitySpecificationRepositoryTrait
      * @param Filter|QueryModifier $specification
      * @param ResultModifier|null  $modifier
      *
-     * @throw Exception\NonUniqueException  If more than one result is found
-     * @throw Exception\NoResultException   If no results found
+     * @throw Exception\NonUniqueException If more than one result is found
+     * @throw Exception\NoResultException  If no results found
      *
      * @return mixed
      */
@@ -80,7 +80,7 @@ trait EntitySpecificationRepositoryTrait
      * @param Filter|QueryModifier $specification
      * @param ResultModifier|null  $modifier
      *
-     * @throw Exception\NonUniqueException  If more than one result is found
+     * @throw Exception\NonUniqueException If more than one result is found
      *
      * @return mixed|null
      */
@@ -99,8 +99,8 @@ trait EntitySpecificationRepositoryTrait
      * @param Filter|QueryModifier $specification
      * @param ResultModifier|null  $modifier
      *
-     * @throw Exception\NonUniqueException  If more than one result is found
-     * @throw Exception\NoResultException   If no results found
+     * @throw Exception\NonUniqueException If more than one result is found
+     * @throw Exception\NoResultException  If no results found
      *
      * @return mixed
      */
@@ -112,6 +112,8 @@ trait EntitySpecificationRepositoryTrait
             return $query->getSingleScalarResult();
         } catch (DoctrineNonUniqueResultException $e) {
             throw new NonUniqueResultException($e->getMessage(), $e->getCode(), $e);
+        } catch (DoctrineNoResultException $e) {
+            throw new NoResultException($e->getMessage(), $e->getCode(), $e);
         }
     }
 
@@ -121,8 +123,7 @@ trait EntitySpecificationRepositoryTrait
      * @param Filter|QueryModifier $specification
      * @param ResultModifier|null  $modifier
      *
-     * @throw Exception\NonUniqueException  If more than one result is found
-     * @throw Exception\NoResultException   If no results found
+     * @throw Exception\NoResultException If no results found
      *
      * @return mixed
      */
@@ -130,7 +131,11 @@ trait EntitySpecificationRepositoryTrait
     {
         $query = $this->getQuery($specification, $modifier);
 
-        return $query->getScalarResult();
+        try {
+            return $query->getScalarResult();
+        } catch (DoctrineNoResultException $e) {
+            throw new NoResultException($e->getMessage(), $e->getCode(), $e);
+        }
     }
 
     /**


### PR DESCRIPTION
The `Doctrine\ORM\AbstractQuery::getSingleScalarResult()` and `Doctrine\ORM\AbstractQuery::getScalarResult()` methods can throw `Doctrine\ORM\NoResultException` wat should be wrpped in `Happyr\DoctrineSpecification\Exception\NoResultException`.