### PR TITLE
Fix problems with PHP-CS-Fixer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /vendor/
 /.php_cs
 /.php_cs.cache
+/.php-cs-fixer.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -18,8 +18,6 @@ $rules = [
     '@Symfony:risky' => true,
     '@PhpCsFixer' => true,
     '@PhpCsFixer:risky' => true,
-    '@PHP56Migration' => true,
-    '@PHP56Migration:risky' => true,
     '@PHP70Migration' => true,
     '@PHP70Migration:risky' => true,
     'header_comment' => [
@@ -54,7 +52,7 @@ $finder = PhpCsFixer\Finder::create()
     ->notPath('bootstrap.php')
 ;
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRules($rules)
     ->setFinder($finder)
     ->setRiskyAllowed(true)

--- a/src/Logic/LogicX.php
+++ b/src/Logic/LogicX.php
@@ -25,9 +25,9 @@ use Happyr\DoctrineSpecification\Specification\Specification;
  */
 abstract class LogicX implements Specification
 {
-    const AND_X = 'andX';
+    public const AND_X = 'andX';
 
-    const OR_X = 'orX';
+    public const OR_X = 'orX';
 
     /**
      * @var string


### PR DESCRIPTION
Fix error of PHP-CS-Fixer:

> Configuration file `.php_cs.dist` is outdated, rename to `.php-cs-fixer.dist.php`. 
