### PR TITLE
Use AbstractQuery::toIterable() to compatible with Doctrine ORM 3.0

### DIFF
--- a/src/Repository/EntitySpecificationRepositoryTrait.php
+++ b/src/Repository/EntitySpecificationRepositoryTrait.php
@@ -176,8 +176,16 @@ trait EntitySpecificationRepositoryTrait
      */
     public function iterate($specification, ?ResultModifier $modifier = null): \Traversable
     {
-        foreach ($this->getQuery($specification, $modifier)->iterate() as $key => $row) {
-            yield $key => current($row);
+        $query = $this->getQuery($specification, $modifier);
+
+        if (method_exists($query, 'toIterable')) {
+            foreach ($query->toIterable() as $key => $row) {
+                yield $key => $row;
+            }
+        } else {
+            foreach ($query->iterate() as $key => $row) {
+                yield $key => current($row);
+            }
         }
     }
 


### PR DESCRIPTION
Method `AbstractQuery::iterate()` is deprecated and will be removed in Doctrine ORM 3.0.