### PR TITLE
Revert "Correct PHPStan generic annotation"

### DIFF
--- a/src/DBALTypesResolver.php
+++ b/src/DBALTypesResolver.php
@@ -21,9 +21,7 @@ final class DBALTypesResolver
     /**
      * The map of supported Doctrine mapping types.
      *
-     * @var string[]
-     *
-     * @phpstan-var array<string, string>
+     * @var array<string, string>
      */
     private static $typesMap = [];
 

--- a/src/Filter/Satisfiable.php
+++ b/src/Filter/Satisfiable.php
@@ -23,8 +23,8 @@ interface Satisfiable
      * @return iterable
      *
      * @phpstan-template T
-     * @phpstan-param iterable<array-key, T> $collection
-     * @phpstan-return iterable<array-key, T>
+     * @phpstan-param iterable<T> $collection
+     * @phpstan-return iterable<T>
      */
     public function filterCollection(iterable $collection, ?string $context = null): iterable;
 

--- a/src/Repository/EntitySpecificationRepository.php
+++ b/src/Repository/EntitySpecificationRepository.php
@@ -19,9 +19,8 @@ use Doctrine\ORM\EntityRepository;
 /**
  * This class allows you to use a Specification to query entities.
  *
- * @phpstan-template T
+ * @template T
  * @phpstan-extends EntityRepository<T>
- * @phpstan-implements EntitySpecificationRepositoryInterface<T>
  */
 class EntitySpecificationRepository extends EntityRepository implements EntitySpecificationRepositoryInterface
 {

--- a/src/Repository/EntitySpecificationRepositoryInterface.php
+++ b/src/Repository/EntitySpecificationRepositoryInterface.php
@@ -23,8 +23,6 @@ use Happyr\DoctrineSpecification\Result\ResultModifier;
 
 /**
  * This interface should be used by an EntityRepository implementing the Specification pattern.
- *
- * @phpstan-template T
  */
 interface EntitySpecificationRepositoryInterface
 {
@@ -35,8 +33,6 @@ interface EntitySpecificationRepositoryInterface
      * @param ResultModifier|null  $modifier
      *
      * @return mixed
-     *
-     * @phpstan-return array<array-key, T>
      */
     public function match($specification, ?ResultModifier $modifier = null);
 
@@ -50,8 +46,6 @@ interface EntitySpecificationRepositoryInterface
      * @throw Exception\NoResultException   If no results found
      *
      * @return mixed
-     *
-     * @phpstan-return T
      */
     public function matchSingleResult($specification, ?ResultModifier $modifier = null);
 
@@ -64,8 +58,6 @@ interface EntitySpecificationRepositoryInterface
      * @throw Exception\NonUniqueException  If more than one result is found
      *
      * @return mixed|null
-     *
-     * @phpstan-return T|null
      */
     public function matchOneOrNullResult($specification, ?ResultModifier $modifier = null);
 
@@ -119,9 +111,7 @@ interface EntitySpecificationRepositoryInterface
      * @param Filter|QueryModifier $specification
      * @param ResultModifier|null  $modifier
      *
-     * @return \Traversable|mixed[]
-     *
-     * @phpstan-return \Traversable<array-key, T>
+     * @return \Traversable<mixed>
      */
     public function iterate($specification, ?ResultModifier $modifier = null): \Traversable;
 }

--- a/src/Repository/EntitySpecificationRepositoryTrait.php
+++ b/src/Repository/EntitySpecificationRepositoryTrait.php
@@ -172,7 +172,7 @@ trait EntitySpecificationRepositoryTrait
      * @param Filter|QueryModifier $specification
      * @param ResultModifier|null  $modifier
      *
-     * @return \Traversable|mixed[]
+     * @return \Traversable<mixed>
      */
     public function iterate($specification, ?ResultModifier $modifier = null): \Traversable
     {


### PR DESCRIPTION
Reverts Happyr/Doctrine-Specification#305

Most of the cases look like:

```php
/** @var array<array-key, JobInterface> $jobs */
$jobs = $this->jobRepository->match(new Running());
```

But there are cases in which we do not select the entire entity, but only individual fields or something else.

Get only profile info.

```php
/** @var array<array-key, array<string, string>> $profiles */
$profiles = $this->jobRepository->match(Spec::andX(
    Spec::select(
        Spec::field('profile.title'),
        Spec::field('profile.name'),
    ),
    new Running(),
));
```

Get count jobs in types.

```php
/** @var array<array-key, array<string, string>> $count_types*/
$count_types = $this->jobRepository->match(Spec::andX(
    Spec::select(Spec::selectAs(Spec::COUNT('type'), 'total')),
    Spec::groupBy('type'),
    new Running(),
));
```

Get related entities.

```php
/** @var array<array-key, Group> $groups */
$groups = $this->jobRepository->match(Spec::andX(
    Spec::select('group'),
    Spec::groupBy('group.id'),
    new Running(),
));
```