### PR TITLE
Use "yield from" for iterate from AbstractQuery::toIterable()

### DIFF
--- a/src/Repository/EntitySpecificationRepositoryTrait.php
+++ b/src/Repository/EntitySpecificationRepositoryTrait.php
@@ -179,9 +179,7 @@ trait EntitySpecificationRepositoryTrait
         $query = $this->getQuery($specification, $modifier);
 
         if (method_exists($query, 'toIterable')) {
-            foreach ($query->toIterable() as $key => $row) {
-                yield $key => $row;
-            }
+            yield from $query->toIterable();
         } else {
             foreach ($query->iterate() as $key => $row) {
                 yield $key => current($row);


### PR DESCRIPTION
Improvement suggested by @jdreesen
https://github.com/Happyr/Doctrine-Specification/pull/306#discussion_r668968337