### PR TITLE
Fix documentation on context usage in specifications

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -118,8 +118,8 @@
 
   ```php
   Spec::andX(
-      Spec::eq('contestant.user.state', State::active()->value()),
-      Spec::eq('contestant.contest.enabled', true)
+      Spec::eq('state', State::active()->value(), 'contestant.user'),
+      Spec::eq('enabled', true, 'contestant.contest')
   );
   ```
 

--- a/docs/1-creatingSpecs.md
+++ b/docs/1-creatingSpecs.md
@@ -131,8 +131,8 @@ class PublishedQuestionnaires extends BaseSpecification
     public function getSpec()
     {
         return Spec::andX(
-            Spec::eq('contestant.user.state', State::active()->value()),
-            Spec::eq('contestant.contest.enabled', true)
+            Spec::eq('state', State::active()->value(), 'contestant.user'),
+            Spec::eq('enabled', true, 'contestant.contest')
         );
     }
 }


### PR DESCRIPTION
Fix #311

```php
Spec::eq('contestant.contest.enabled', true)
```

should be

```php
Spec::eq('enabled', true, 'contestant.contest')
```