### PR TITLE
Support Symfony 7

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,6 +18,7 @@ jobs:
                     - '7.3'
                     - '7.4'
                     - '8.0'
+                    - '8.2'
                 variant: [normal]
                 include:
                     - php-version: '7.2'
@@ -32,6 +33,9 @@ jobs:
                     - php-version: '8.0'
                       dependencies: highest
                       variant: 'doctrine/orm:~2.7 symfony/property-access:^6.0'
+                    - php-version: '8.2'
+                      dependencies: highest
+                      variant: 'doctrine/orm:~2.7 symfony/property-access:^7.0'
         steps:
             - name: Checkout
               uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,11 @@
     "require": {
         "php": ">=7.2",
         "doctrine/orm": "~2.5",
-        "symfony/property-access": "^4.0 || ^5.2 || ^6.0",
+        "symfony/property-access": "^4.0 || ^5.2 || ^6.0 || ^7.0",
         "symfony/polyfill-php80": "^1.20"
     },
     "require-dev": {
-        "phpspec/phpspec": "~6.3"
+        "phpspec/phpspec": "~6.3 || ^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Operand/PlatformFunction/DateAdd.php
+++ b/src/Operand/PlatformFunction/DateAdd.php
@@ -119,6 +119,10 @@ final class DateAdd implements Operand
 
         $new_date = new \DateTimeImmutable($date->format('Y-m-d H:i:s'), $date->getTimezone());
 
+        if (0 > (float) $value) {
+            return $new_date->modify(sprintf('%d %s', $value, $this->unit));
+        }
+
         return $new_date->modify(sprintf('+%d %s', $value, $this->unit));
     }
 }

--- a/src/Operand/PlatformFunction/DateSub.php
+++ b/src/Operand/PlatformFunction/DateSub.php
@@ -119,6 +119,9 @@ final class DateSub implements Operand
 
         $new_date = new \DateTimeImmutable($date->format('Y-m-d H:i:s'), $date->getTimezone());
 
+        if (0 > (float) $value) {
+            return $new_date->modify(sprintf('+%d %s', abs((float) $value), $this->unit));
+        }
         return $new_date->modify(sprintf('-%d %s', $value, $this->unit));
     }
 }


### PR DESCRIPTION
Since `symfony/property-access` 7.0 requires php8.2 and php8.2 had some changes in datetime format: https://www.php.net/manual/en/datetime.formats.php (end of document) I had to make some changes
@peter-gribanov